### PR TITLE
Mouser product search (issues #24, #25, #27)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-05-16
+
+### feat: add Mouser API Postman collection (issue #25)
+
+- Add `api/mouser/mouser.postman_collection.json` + `api/mouser/mouser.postman_environment.json` — Postman v2.1.0 collection covering Mouser Search API (`KeywordSearch`, `PartNumberSearch`, `ManufacturerList`); auth via `?apiKey={{api_key}}` query param (no OAuth2 token flow needed)
+- Add `postman/collections/Mouser API/` YAML mirror (`Search/{KeywordSearch,PartNumberSearch,ManufacturerList}.request.yaml`) and `postman/environments/Mouser API Environment.environment.yaml` to match the dual-format layout established for DigiKey
+- Endpoint selection: V1 `/api/v1/search/keyword` + `/api/v1/search/partnumber` (no required-manufacturer-name complication) and V2 `/api/v2/search/manufacturerlist` (clean api-key smoke test)
+- Smoke-tested every URL with `curl` + a bogus `apiKey=PROBE` before committing — all three return HTTP 200 with a clean body-level error, confirming the paths exist and accept the expected body shape (no repeat of the #19 speculative-URL trap)
+
 ## 2026-05-13
 
 ### feat: DigiKey product search in web app (issue #20)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026-05-17
+
+### feat: Mouser product search in web app (issue #24)
+
+- Add local FastAPI backend at `api/mouser/server/` on **port 8001** (alongside the DigiKey backend on 8000 — both can run simultaneously) — reads `MOUSER_API_KEY` from `.env`, no OAuth2 token flow needed (Mouser auth is a per-request `?apiKey=` query string)
+- New `GET /pricing?manufacturer_part_number=<MPN>` calls `POST https://api.mouser.com/api/v1/search/partnumber` and normalizes the response to match the DigiKey backend's shape: top-level `unit_price` / `tier_quantity` from `tiers[-2]` (second-to-last tier; same selection rule as DigiKey for UX parity), plus `tiers[]` sorted ascending and a `mouser_part_number` echo for reference
+- Mouser-specific quirks handled: `Parts[]` can contain multiple matches → pick by exact `ManufacturerPartNumber` (case-insensitive), else first; `PriceBreaks[].Price` arrives as a string ("$0.51" or "0.51") → strip currency symbol and `float()`, tolerating comma-as-decimal locales; surfaces body-level `Errors[]` as 502s
+- Add new static page `web/mouser-search.html` — near-clone of `web/search.html` with port 8001 and Mouser-specific labels (placeholder `NE555P`, `Mouser:` caption); displays only the selected tier as `Qty <N> → $<P> USD / unit`
+- Restructure `web/index.html` bottom-right link area into a stacked two-link nav: rename the existing "Product search →" to "DigiKey search →" for clarity, add new "Mouser search →" beneath
+- Document the new page in `web/TEST-PLAN.md` § 7 (homepage link, backend-unreachable, local-backend smoke including a "both backends side by side" case, defense-in-depth)
+- Both backends remain intended for local development; the frontend's `BACKEND_URL` constant is the only edit needed to migrate to a hosted serverless function later
+- Followed by issue #27 (sub-issue) entry below: `web/search.html` → `web/digikey-search.html` rename for naming symmetry
+
+### refactor: rename web/search.html to web/digikey-search.html (issue #27, sub-issue of #24)
+
+- `git mv web/search.html web/digikey-search.html` (preserves history)
+- Inside the renamed file, update `<title>` and `<h1>` from "Product Search" to "DigiKey Product Search" for symmetry with `web/mouser-search.html`'s `<h1>Mouser Product Search</h1>`
+- Update references: `web/index.html` anchor target; `web/TEST-PLAN.md` § 6 page name + URL examples; `api/digikey/server/main.py` module docstring; `api/digikey/server/README.md` relative link in the header
+- Deployed URL `https://wongvin.github.io/firstcontact/search.html` will 404 after merge — the only known link was the homepage anchor (now updated); no redirect added since GH Pages doesn't support server-side redirects without a build step
+
 ## 2026-05-16
 
 ### feat: add Mouser API Postman collection (issue #25)

--- a/api/digikey/server/README.md
+++ b/api/digikey/server/README.md
@@ -1,6 +1,6 @@
 # DigiKey pricing proxy
 
-Local FastAPI backend that proxies DigiKey ProductPricing API calls for [`web/search.html`](../../../web/search.html). Holds OAuth2 client credentials in a local `.env` so the static frontend never sees them.
+Local FastAPI backend that proxies DigiKey ProductPricing API calls for [`web/digikey-search.html`](../../../web/digikey-search.html). Holds OAuth2 client credentials in a local `.env` so the static frontend never sees them.
 
 ## Setup
 

--- a/api/mouser/mouser.postman_collection.json
+++ b/api/mouser/mouser.postman_collection.json
@@ -1,0 +1,78 @@
+{
+  "info": {
+    "name": "Mouser API",
+    "description": "Postman collection for Mouser Search API (https://api.mouser.com/api/docs/V2). Auth is a per-request `?apiKey={{api_key}}` query parameter — no OAuth2 token flow. Uses V1 endpoints for simple keyword/part-number searches (no required manufacturer filter) and V2 for ManufacturerList.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": "1.0.0"
+  },
+  "item": [
+    {
+      "name": "Search",
+      "item": [
+        {
+          "name": "KeywordSearch",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"SearchByKeywordRequest\": {\n    \"keyword\": \"{{keyword}}\",\n    \"records\": 25,\n    \"startingRecord\": 0,\n    \"searchOptions\": \"\",\n    \"searchWithYourSignUpLanguage\": \"\"\n  }\n}"
+            },
+            "url": {
+              "raw": "https://api.mouser.com/api/v1/search/keyword?apiKey={{api_key}}",
+              "protocol": "https",
+              "host": ["api", "mouser", "com"],
+              "path": ["api", "v1", "search", "keyword"],
+              "query": [
+                { "key": "apiKey", "value": "{{api_key}}" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "PartNumberSearch",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"SearchByPartRequest\": {\n    \"mouserPartNumber\": \"{{part_number}}\",\n    \"partSearchOptions\": \"\"\n  }\n}"
+            },
+            "url": {
+              "raw": "https://api.mouser.com/api/v1/search/partnumber?apiKey={{api_key}}",
+              "protocol": "https",
+              "host": ["api", "mouser", "com"],
+              "path": ["api", "v1", "search", "partnumber"],
+              "query": [
+                { "key": "apiKey", "value": "{{api_key}}" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "ManufacturerList",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api.mouser.com/api/v2/search/manufacturerlist?apiKey={{api_key}}",
+              "protocol": "https",
+              "host": ["api", "mouser", "com"],
+              "path": ["api", "v2", "search", "manufacturerlist"],
+              "query": [
+                { "key": "apiKey", "value": "{{api_key}}" }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/api/mouser/mouser.postman_environment.json
+++ b/api/mouser/mouser.postman_environment.json
@@ -1,0 +1,12 @@
+{
+  "id": "mouser-env",
+  "name": "Mouser API Environment",
+  "values": [
+    { "key": "api_key", "value": "", "enabled": true },
+    { "key": "keyword", "value": "NE555", "enabled": true },
+    { "key": "part_number", "value": "595-NE555P", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-05-16T00:00:00.000Z",
+  "_postman_exported_using": "Postman/10.0"
+}

--- a/api/mouser/server/.env.example
+++ b/api/mouser/server/.env.example
@@ -1,0 +1,1 @@
+MOUSER_API_KEY=

--- a/api/mouser/server/README.md
+++ b/api/mouser/server/README.md
@@ -1,0 +1,70 @@
+# Mouser pricing proxy
+
+Local FastAPI backend that proxies Mouser's PartNumberSearch API for [`web/mouser-search.html`](../../../web/mouser-search.html). Holds the API key in a local `.env` so the static frontend never sees it.
+
+Companion to `api/digikey/server/` — same architecture, different distributor. Both can run side-by-side (Mouser on **port 8001**, DigiKey on 8000).
+
+## Setup
+
+```bash
+cd api/mouser/server
+cp .env.example .env
+# Edit .env and fill in MOUSER_API_KEY from https://www.mouser.com/api-hub/
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Run
+
+```bash
+uvicorn main:app --port 8001
+```
+
+CORS allowed origins:
+- `http://localhost:5500` (VS Code Live Server default)
+- `http://localhost:8080` (e.g. `python -m http.server 8080` from `web/`)
+- `https://wongvin.github.io` (deployed GH Pages origin)
+
+## Endpoints
+
+### `GET /health`
+
+```
+{ "status": "ok" }
+```
+
+### `GET /pricing?manufacturer_part_number=<MPN>`
+
+Returns volume-tier pricing for a manufacturer part number from Mouser. Picks the **second-to-last tier** as the headline `unit_price` / `tier_quantity` (same selection rule as the DigiKey backend, for UX parity).
+
+```bash
+curl 'http://localhost:8001/pricing?manufacturer_part_number=NE555P'
+```
+
+Response shape (deliberately mirrors the DigiKey backend so the frontend logic carries over):
+
+```json
+{
+  "manufacturer_part_number": "NE555P",
+  "mouser_part_number": "595-NE555P",
+  "currency": "USD",
+  "unit_price": 0.36,
+  "tier_quantity": 10,
+  "tiers": [
+    { "quantity": 1, "unit_price": 0.51 },
+    { "quantity": 10, "unit_price": 0.36 },
+    { "quantity": 100, "unit_price": 0.28 }
+  ]
+}
+```
+
+The frontend currently displays only the headline tier; the full `tiers` array is included for future use.
+
+## Notes
+
+- Mouser auth is a per-request `?apiKey=<KEY>` query parameter — no OAuth2 token flow, no token cache.
+- Underlying API: `POST https://api.mouser.com/api/v1/search/partnumber`. The Postman collection at `api/mouser/mouser.postman_collection.json` documents the same endpoints.
+- `Price` in Mouser's PriceBreaks rows arrives as a string (e.g. `"$0.51"` or `"0.51"`); the client strips currency symbols and parses as float, tolerating comma-as-decimal locales.
+- Multiple `Parts[]` matches: the client picks the entry whose `ManufacturerPartNumber` matches the user's input case-insensitively, else falls back to the first match.

--- a/api/mouser/server/main.py
+++ b/api/mouser/server/main.py
@@ -1,4 +1,4 @@
-"""FastAPI app exposing GET /pricing for web/digikey-search.html."""
+"""FastAPI app exposing GET /pricing for web/mouser-search.html."""
 
 from __future__ import annotations
 
@@ -6,12 +6,12 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 
-from digikey_client import DigiKeyError, get_pricing
+from mouser_client import MouserError, get_pricing
 
 
 load_dotenv()
 
-app = FastAPI(title="DigiKey pricing proxy", version="0.1.0")
+app = FastAPI(title="Mouser pricing proxy", version="0.1.0")
 
 app.add_middleware(
     CORSMiddleware,
@@ -32,9 +32,9 @@ async def health() -> dict[str, str]:
 
 @app.get("/pricing")
 async def pricing(
-    manufacturer_part_number: str = Query(..., min_length=1, description="Manufacturer part number, e.g. STM32F407VGT6"),
+    manufacturer_part_number: str = Query(..., min_length=1, description="Manufacturer part number, e.g. NE555P"),
 ):
     try:
         return await get_pricing(manufacturer_part_number)
-    except DigiKeyError as err:
+    except MouserError as err:
         raise HTTPException(status_code=502, detail=str(err))

--- a/api/mouser/server/mouser_client.py
+++ b/api/mouser/server/mouser_client.py
@@ -1,0 +1,131 @@
+"""Mouser API client: SearchByPartRequest call + response normalization.
+
+No token caching needed — Mouser auth is a per-request `?apiKey=` query string.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+import httpx
+
+
+PART_NUMBER_SEARCH_URL = "https://api.mouser.com/api/v1/search/partnumber"
+
+
+class MouserError(Exception):
+    """Raised when Mouser returns an error response or required config is missing."""
+
+
+def _get_api_key() -> str:
+    api_key = os.environ.get("MOUSER_API_KEY")
+    if not api_key:
+        raise MouserError("MOUSER_API_KEY must be set in the environment (.env).")
+    return api_key
+
+
+def _parse_price(price_str: str) -> float:
+    """Mouser returns Price as a string like '$0.51' or '0.51'. Strip non-numeric prefix and parse."""
+    if not price_str:
+        raise MouserError(f"Empty price string in Mouser response.")
+    # Strip leading currency symbols and whitespace; tolerate locale variants
+    cleaned = re.sub(r"^[^\d.,-]+", "", price_str.strip())
+    # Normalize comma-as-decimal locales by replacing the last comma with a dot if no dot present
+    if "." not in cleaned and "," in cleaned:
+        cleaned = cleaned.replace(",", ".")
+    else:
+        cleaned = cleaned.replace(",", "")
+    try:
+        return float(cleaned)
+    except ValueError as err:
+        raise MouserError(f"Could not parse Mouser price string {price_str!r}: {err}") from err
+
+
+def _pick_part(parts: list[dict[str, Any]], requested_mpn: str) -> dict[str, Any]:
+    """Pick the Part whose ManufacturerPartNumber matches user input (case-insensitive); else first."""
+    requested = requested_mpn.strip().casefold()
+    for part in parts:
+        if (part.get("ManufacturerPartNumber") or "").casefold() == requested:
+            return part
+    return parts[0]
+
+
+def _select_tier(tiers: list[dict[str, Any]]) -> dict[str, Any]:
+    """Pick the second-to-last tier (or only tier if fewer than 2). Same rule as DigiKey backend."""
+    if not tiers:
+        raise MouserError("Mouser response contained no PriceBreaks.")
+    if len(tiers) < 2:
+        return tiers[0]
+    return tiers[-2]
+
+
+def _normalize_tiers(raw_breaks: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str]:
+    """Convert Mouser PriceBreaks rows into [{quantity, unit_price}] sorted ascending,
+    and return the currency string from the first row."""
+    normalized: list[dict[str, Any]] = []
+    currency = "USD"
+    for row in raw_breaks:
+        normalized.append(
+            {
+                "quantity": int(row["Quantity"]),
+                "unit_price": _parse_price(row.get("Price") or ""),
+            }
+        )
+        if row.get("Currency"):
+            currency = row["Currency"]
+    normalized.sort(key=lambda t: t["quantity"])
+    return normalized, currency
+
+
+async def get_pricing(manufacturer_part_number: str) -> dict[str, Any]:
+    """Fetch volume-tier pricing for a manufacturer part number from Mouser."""
+    api_key = _get_api_key()
+    body = {
+        "SearchByPartRequest": {
+            "mouserPartNumber": manufacturer_part_number,
+            "partSearchOptions": "",
+        }
+    }
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            PART_NUMBER_SEARCH_URL,
+            params={"apiKey": api_key},
+            json=body,
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+        )
+
+    if resp.status_code != 200:
+        raise MouserError(f"PartNumberSearch failed ({resp.status_code}): {resp.text}")
+
+    payload = resp.json()
+    errors = payload.get("Errors") or []
+    if errors:
+        first_msg = errors[0].get("Message") or "Mouser returned an error."
+        raise MouserError(first_msg)
+
+    results = payload.get("SearchResults") or {}
+    parts = results.get("Parts") or []
+    if not parts:
+        raise MouserError(f"Part not found: {manufacturer_part_number}")
+
+    matched = _pick_part(parts, manufacturer_part_number)
+    raw_breaks = matched.get("PriceBreaks") or []
+    if not raw_breaks:
+        raise MouserError(
+            f"No PriceBreaks returned for {manufacturer_part_number}. "
+            f"This part may have no published pricing in the API."
+        )
+
+    tiers, currency = _normalize_tiers(raw_breaks)
+    selected = _select_tier(tiers)
+
+    return {
+        "manufacturer_part_number": matched.get("ManufacturerPartNumber") or manufacturer_part_number,
+        "mouser_part_number": matched.get("MouserPartNumber"),
+        "currency": currency,
+        "unit_price": selected["unit_price"],
+        "tier_quantity": selected["quantity"],
+        "tiers": tiers,
+    }

--- a/api/mouser/server/requirements.txt
+++ b/api/mouser/server/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27
+httpx>=0.27
+python-dotenv>=1.0

--- a/postman/collections/Mouser API/.resources/definition.yaml
+++ b/postman/collections/Mouser API/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+description: Postman collection for Mouser Search API V2 (https://api.mouser.com/api/docs/V2). Auth is a per-request `?apiKey={{api_key}}` query parameter — no OAuth2 token flow.

--- a/postman/collections/Mouser API/Search/.resources/definition.yaml
+++ b/postman/collections/Mouser API/Search/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 1000

--- a/postman/collections/Mouser API/Search/KeywordSearch.request.yaml
+++ b/postman/collections/Mouser API/Search/KeywordSearch.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+url: https://api.mouser.com/api/v1/search/keyword?apiKey={{api_key}}
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "SearchByKeywordRequest": {
+        "keyword": "{{keyword}}",
+        "records": 25,
+        "startingRecord": 0,
+        "searchOptions": "",
+        "searchWithYourSignUpLanguage": ""
+      }
+    }
+order: 1000

--- a/postman/collections/Mouser API/Search/ManufacturerList.request.yaml
+++ b/postman/collections/Mouser API/Search/ManufacturerList.request.yaml
@@ -1,0 +1,4 @@
+$kind: http-request
+url: https://api.mouser.com/api/v2/search/manufacturerlist?apiKey={{api_key}}
+method: GET
+order: 3000

--- a/postman/collections/Mouser API/Search/PartNumberSearch.request.yaml
+++ b/postman/collections/Mouser API/Search/PartNumberSearch.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+url: https://api.mouser.com/api/v1/search/partnumber?apiKey={{api_key}}
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {
+      "SearchByPartRequest": {
+        "mouserPartNumber": "{{part_number}}",
+        "partSearchOptions": ""
+      }
+    }
+order: 2000

--- a/postman/environments/Mouser API Environment.environment.yaml
+++ b/postman/environments/Mouser API Environment.environment.yaml
@@ -1,0 +1,8 @@
+name: Mouser API Environment
+values:
+  - key: api_key
+    value: ''
+  - key: keyword
+    value: NE555
+  - key: part_number
+    value: 595-NE555P

--- a/web/TEST-PLAN.md
+++ b/web/TEST-PLAN.md
@@ -117,20 +117,20 @@ This feature was originally a static day-of-year-rotating array (issue #2) and w
 
 ## 6. Product search (issue #20)
 
-The `web/search.html` page is a static frontend that calls a **local** Python FastAPI backend at `http://localhost:8000` (`api/digikey/server/`). The live deployed page exists but is non-functional unless the user has the backend running with their own DigiKey credentials.
+The `web/digikey-search.html` page is a static frontend that calls a **local** Python FastAPI backend at `http://localhost:8000` (`api/digikey/server/`). The live deployed page exists but is non-functional unless the user has the backend running with their own DigiKey credentials.
 
 ### 6a. Homepage link
 
 | ID | Steps | Expected |
 |---|---|---|
 | 6a.1 | Open `https://wongvin.github.io/firstcontact/`. | Bottom-right shows a "Product search →" link in the glass-card style; does not overlap the "Changes made this week" panel. |
-| 6a.2 | Click the link. | Navigates to `/firstcontact/search.html`. New page loads with same gradient background, a "← Home" link top-left, an `<h1>Product Search</h1>`, a subtitle, and an MPN input form. |
+| 6a.2 | Click the link. | Navigates to `/firstcontact/digikey-search.html`. New page loads with same gradient background, a "← Home" link top-left, an `<h1>DigiKey Product Search</h1>`, a subtitle, and an MPN input form. |
 
 ### 6b. Backend unreachable (live site, no local server)
 
 | ID | Steps | Expected |
 |---|---|---|
-| 6b.1 | On the live `/search.html` with no local backend running, type `STM32F407VGT6` and submit. | After a brief "Loading…", an error message appears: "Backend unreachable at `http://localhost:8000` — start the local server (see `api/digikey/server/README.md`)." Form re-enables; no console crash. |
+| 6b.1 | On the live `/digikey-search.html` with no local backend running, type `STM32F407VGT6` and submit. | After a brief "Loading…", an error message appears: "Backend unreachable at `http://localhost:8000` — start the local server (see `api/digikey/server/README.md`)." Form re-enables; no console crash. |
 
 ### 6c. Local backend smoke (developer-only)
 
@@ -140,7 +140,7 @@ Prerequisite: backend up per `api/digikey/server/README.md` with real `DIGIKEY_C
 |---|---|---|
 | 6c.1 | `curl http://localhost:8000/health` | Returns `{"status":"ok"}`. |
 | 6c.2 | `curl 'http://localhost:8000/pricing?manufacturer_part_number=STM32F407VGT6'` | HTTP 200 with JSON containing `manufacturer_part_number`, `digikey_part_number`, `currency: "USD"`, non-empty `tiers` array (sorted ascending by `quantity`), and a `unit_price` / `tier_quantity` pair matching `tiers[-2]` (or `tiers[0]` if fewer than 2 entries). |
-| 6c.3 | Serve `web/` locally (`cd web && python -m http.server 8080`), open `http://localhost:8080/search.html`, type a known MPN, submit. | Headline renders as `Qty <N> → $<P> USD / unit` with both numbers in the same large font weight/size. A muted line below shows `<MPN>  ·  DK: <DigiKey-PN>`. No tier table appears. |
+| 6c.3 | Serve `web/` locally (`cd web && python -m http.server 8080`), open `http://localhost:8080/digikey-search.html`, type a known MPN, submit. | Headline renders as `Qty <N> → $<P> USD / unit` with both numbers in the same large font weight/size. A muted line below shows `<MPN>  ·  DK: <DigiKey-PN>`. No tier table appears. |
 | 6c.4 | Submit a bogus MPN like `NOTAPART_xyz`. | After "Loading…", an error message renders (DigiKey 404 surfaced as a 502 from the proxy with a "Part not found" detail), not the headline. |
 
 ### 6d. Defense-in-depth
@@ -148,6 +148,41 @@ Prerequisite: backend up per `api/digikey/server/README.md` with real `DIGIKEY_C
 | ID | Steps | Expected |
 |---|---|---|
 | 6d.1 | DevTools → Elements → after a successful search, inspect the `.headline` and `.part-line` nodes. | Inner content is Text nodes only — no nested `<a>`, `<span>` (except the deliberate ones), and certainly no markup injected from the backend response. (Confirms `document.createElement` + `textContent` / `createTextNode` rendering path.) |
+
+## 7. Mouser product search (issue #24)
+
+The `web/mouser-search.html` page is a static frontend that calls a **local** Python FastAPI backend at `http://localhost:8001` (`api/mouser/server/`). Same shape as § 6 but for Mouser instead of DigiKey, and on a different port so both backends can run side by side.
+
+### 7a. Homepage link
+
+| ID | Steps | Expected |
+|---|---|---|
+| 7a.1 | Open `https://wongvin.github.io/firstcontact/`. | Bottom-right shows two stacked glass-card links: "DigiKey search →" (top) and "Mouser search →" (bottom). Neither overlaps the "Changes made this week" panel. |
+| 7a.2 | Click the Mouser link. | Navigates to `/firstcontact/mouser-search.html`. New page loads with same gradient background, a "← Home" link top-left, an `<h1>Mouser Product Search</h1>`, a subtitle, and an MPN input form (placeholder `NE555P`). |
+
+### 7b. Backend unreachable (live site, no local server)
+
+| ID | Steps | Expected |
+|---|---|---|
+| 7b.1 | On the live `/mouser-search.html` with no local backend running, type `NE555P` and submit. | After a brief "Loading…", an error message appears: "Backend unreachable at `http://localhost:8001` — start the local server (see `api/mouser/server/README.md`)." Form re-enables; no console crash. |
+
+### 7c. Local backend smoke (developer-only)
+
+Prerequisite: backend up per `api/mouser/server/README.md` with a real `MOUSER_API_KEY`.
+
+| ID | Steps | Expected |
+|---|---|---|
+| 7c.1 | `curl http://localhost:8001/health` | Returns `{"status":"ok"}`. |
+| 7c.2 | `curl 'http://localhost:8001/pricing?manufacturer_part_number=NE555P'` | HTTP 200 with JSON containing `manufacturer_part_number`, `mouser_part_number`, `currency`, non-empty `tiers` array (sorted ascending by `quantity`), and a `unit_price` / `tier_quantity` pair matching `tiers[-2]` (or `tiers[0]` if fewer than 2 entries). |
+| 7c.3 | Serve `web/` locally (`cd web && python3 -m http.server 8080`), open `http://localhost:8080/mouser-search.html`, type a known MPN, submit. | Headline renders as `Qty <N> → $<P> USD / unit` with both numbers in the same large font weight/size. A muted line below shows `<MPN>  ·  Mouser: <Mouser-PN>`. No tier table appears. |
+| 7c.4 | Submit a bogus MPN like `NOTAPART_xyz`. | After "Loading…", an error message renders ("Part not found" surfaced as a 502 from the proxy), not the headline. |
+| 7c.5 | Run both backends side by side: `uvicorn main:app --port 8000` from `api/digikey/server` and `--port 8001` from `api/mouser/server`. Open both `digikey-search.html` and `mouser-search.html` in two tabs. | Each page only talks to its own backend; searches in one tab don't affect the other. |
+
+### 7d. Defense-in-depth
+
+| ID | Steps | Expected |
+|---|---|---|
+| 7d.1 | DevTools → Elements → after a successful search, inspect the `.headline` and `.part-line` nodes. | Inner content is Text nodes only — no nested markup injected from the backend response. (Confirms `document.createElement` + `textContent` / `createTextNode` rendering path, mirroring the DigiKey page.) |
 
 ## Exit criteria
 

--- a/web/digikey-search.html
+++ b/web/digikey-search.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DigiKey Product Search</title>
+  <style>
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      color: white;
+      text-align: center;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 2rem 1rem;
+      box-sizing: border-box;
+    }
+    a.home-link {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      color: rgba(255, 255, 255, 0.85);
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 0.4rem 0.75rem;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 0.4rem;
+      background: rgba(255, 255, 255, 0.08);
+    }
+    a.home-link:hover { color: white; }
+    h1 {
+      font-size: 2.25rem;
+      margin: 0 0 0.5rem;
+    }
+    p.subtitle {
+      font-size: 1rem;
+      opacity: 0.85;
+      margin: 0 0 2rem;
+    }
+    .card {
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 0.75rem;
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      padding: 1.5rem;
+      width: min(28rem, 100%);
+      box-sizing: border-box;
+    }
+    form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      width: min(28rem, 100%);
+      box-sizing: border-box;
+    }
+    label {
+      text-align: left;
+      font-size: 0.85rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      opacity: 0.85;
+    }
+    input[type="text"] {
+      font-size: 1rem;
+      padding: 0.65rem 0.8rem;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      border-radius: 0.4rem;
+      background: rgba(255, 255, 255, 0.1);
+      color: white;
+      outline: none;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    input[type="text"]::placeholder { color: rgba(255, 255, 255, 0.55); }
+    input[type="text"]:focus { border-color: rgba(255, 255, 255, 0.7); }
+    button {
+      font-size: 1rem;
+      padding: 0.65rem 1rem;
+      border: none;
+      border-radius: 0.4rem;
+      background: rgba(255, 255, 255, 0.85);
+      color: #4a3a6c;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:hover { background: white; }
+    button:disabled { opacity: 0.6; cursor: not-allowed; }
+    #result {
+      margin-top: 1.5rem;
+      min-height: 5rem;
+    }
+    .headline {
+      display: flex;
+      align-items: baseline;
+      justify-content: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      font-size: 2.25rem;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }
+    .headline .sep { opacity: 0.7; font-weight: 400; }
+    .part-line {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+      opacity: 0.8;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .muted {
+      opacity: 0.75;
+      font-size: 0.95rem;
+    }
+    .error { color: #ffd6d6; }
+  </style>
+</head>
+<body>
+  <a class="home-link" href="index.html">← Home</a>
+
+  <h1>DigiKey Product Search</h1>
+  <p class="subtitle">Volume unit pricing from DigiKey, by manufacturer part number.</p>
+
+  <form id="search-form" autocomplete="off">
+    <label for="mpn">Manufacturer Part Number</label>
+    <input id="mpn" type="text" name="mpn" placeholder="STM32F407VGT6" required />
+    <button id="submit-btn" type="submit">Search</button>
+  </form>
+
+  <div id="result" aria-live="polite"></div>
+
+  <script>
+    const BACKEND_URL = "http://localhost:8000";
+
+    const form = document.getElementById('search-form');
+    const submitBtn = document.getElementById('submit-btn');
+    const input = document.getElementById('mpn');
+    const result = document.getElementById('result');
+
+    function setMessage(text, className) {
+      result.replaceChildren();
+      const p = document.createElement('p');
+      if (className) p.className = className;
+      p.textContent = text;
+      result.appendChild(p);
+    }
+
+    function renderResult(data) {
+      result.replaceChildren();
+
+      const headline = document.createElement('div');
+      headline.className = 'headline';
+
+      const qtySpan = document.createElement('span');
+      qtySpan.textContent = 'Qty ' + data.tier_quantity.toLocaleString();
+      headline.appendChild(qtySpan);
+
+      const sep = document.createElement('span');
+      sep.className = 'sep';
+      sep.textContent = '→';
+      headline.appendChild(sep);
+
+      const priceSpan = document.createElement('span');
+      const unitPrice = Number(data.unit_price).toFixed(4).replace(/0+$/, '').replace(/\.$/, '');
+      priceSpan.textContent = '$' + unitPrice + ' ' + data.currency + ' / unit';
+      headline.appendChild(priceSpan);
+
+      result.appendChild(headline);
+
+      const partLine = document.createElement('p');
+      partLine.className = 'part-line';
+      const mpnText = document.createTextNode(data.manufacturer_part_number);
+      partLine.appendChild(mpnText);
+      if (data.digikey_part_number) {
+        const sepNode = document.createElement('span');
+        sepNode.textContent = '  ·  DK: ';
+        partLine.appendChild(sepNode);
+        const dkText = document.createTextNode(data.digikey_part_number);
+        partLine.appendChild(dkText);
+      }
+      result.appendChild(partLine);
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const mpn = input.value.trim();
+      if (!mpn) return;
+      submitBtn.disabled = true;
+      setMessage('Loading…', 'muted');
+      try {
+        const url = BACKEND_URL + '/pricing?manufacturer_part_number=' + encodeURIComponent(mpn);
+        const res = await fetch(url);
+        if (!res.ok) {
+          let detail = 'HTTP ' + res.status;
+          try {
+            const body = await res.json();
+            if (body && body.detail) detail = body.detail;
+          } catch (_) {}
+          throw new Error(detail);
+        }
+        const data = await res.json();
+        renderResult(data);
+      } catch (err) {
+        const msg = err && err.message ? err.message : String(err);
+        if (msg.includes('Failed to fetch') || msg.includes('NetworkError')) {
+          setMessage('Backend unreachable at ' + BACKEND_URL + ' — start the local server (see api/digikey/server/README.md).', 'error');
+        } else {
+          setMessage(msg, 'error');
+        }
+      } finally {
+        submitBtn.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -72,10 +72,16 @@
       margin-left: -1.25rem;
       opacity: 0.7;
     }
-    a.tool-link {
+    .tool-links {
       position: fixed;
       bottom: 1rem;
       right: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      align-items: stretch;
+    }
+    a.tool-link {
       color: rgba(255, 255, 255, 0.85);
       text-decoration: none;
       font-size: 0.9rem;
@@ -85,6 +91,7 @@
       background: rgba(255, 255, 255, 0.08);
       backdrop-filter: blur(8px);
       -webkit-backdrop-filter: blur(8px);
+      text-align: right;
     }
     a.tool-link:hover { color: white; }
   </style>
@@ -102,7 +109,10 @@
     <h2>Changes made this week</h2>
     <ol id="recent-tasks-list"><li class="empty">Loading…</li></ol>
   </aside>
-  <a class="tool-link" href="search.html">Product search →</a>
+  <nav class="tool-links" aria-label="Product search tools">
+    <a class="tool-link" href="digikey-search.html">DigiKey search →</a>
+    <a class="tool-link" href="mouser-search.html">Mouser search →</a>
+  </nav>
   <script>
     document.getElementById('device').textContent =
       'You are on: ' + navigator.userAgent.split('(')[1].split(')')[0];

--- a/web/mouser-search.html
+++ b/web/mouser-search.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Product Search</title>
+  <title>Mouser Product Search</title>
   <style>
     html, body {
       margin: 0;
@@ -43,16 +43,6 @@
       font-size: 1rem;
       opacity: 0.85;
       margin: 0 0 2rem;
-    }
-    .card {
-      background: rgba(255, 255, 255, 0.12);
-      border: 1px solid rgba(255, 255, 255, 0.25);
-      border-radius: 0.75rem;
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
-      padding: 1.5rem;
-      width: min(28rem, 100%);
-      box-sizing: border-box;
     }
     form {
       display: flex;
@@ -123,19 +113,19 @@
 <body>
   <a class="home-link" href="index.html">← Home</a>
 
-  <h1>Product Search</h1>
-  <p class="subtitle">Volume unit pricing from DigiKey, by manufacturer part number.</p>
+  <h1>Mouser Product Search</h1>
+  <p class="subtitle">Volume unit pricing from Mouser, by manufacturer part number.</p>
 
   <form id="search-form" autocomplete="off">
     <label for="mpn">Manufacturer Part Number</label>
-    <input id="mpn" type="text" name="mpn" placeholder="STM32F407VGT6" required />
+    <input id="mpn" type="text" name="mpn" placeholder="NE555P" required />
     <button id="submit-btn" type="submit">Search</button>
   </form>
 
   <div id="result" aria-live="polite"></div>
 
   <script>
-    const BACKEND_URL = "http://localhost:8000";
+    const BACKEND_URL = "http://localhost:8001";
 
     const form = document.getElementById('search-form');
     const submitBtn = document.getElementById('submit-btn');
@@ -176,12 +166,12 @@
       partLine.className = 'part-line';
       const mpnText = document.createTextNode(data.manufacturer_part_number);
       partLine.appendChild(mpnText);
-      if (data.digikey_part_number) {
+      if (data.mouser_part_number) {
         const sepNode = document.createElement('span');
-        sepNode.textContent = '  ·  DK: ';
+        sepNode.textContent = '  ·  Mouser: ';
         partLine.appendChild(sepNode);
-        const dkText = document.createTextNode(data.digikey_part_number);
-        partLine.appendChild(dkText);
+        const mouserText = document.createTextNode(data.mouser_part_number);
+        partLine.appendChild(mouserText);
       }
       result.appendChild(partLine);
     }
@@ -208,7 +198,7 @@
       } catch (err) {
         const msg = err && err.message ? err.message : String(err);
         if (msg.includes('Failed to fetch') || msg.includes('NetworkError')) {
-          setMessage('Backend unreachable at ' + BACKEND_URL + ' — start the local server (see api/digikey/server/README.md).', 'error');
+          setMessage('Backend unreachable at ' + BACKEND_URL + ' — start the local server (see api/mouser/server/README.md).', 'error');
         } else {
           setMessage(msg, 'error');
         }


### PR DESCRIPTION
## Summary

Closes #24. Closes #25. Closes #27.

Adds Mouser product search alongside the existing DigiKey one. Single branch covers three issues:
- **#25** — Mouser API Postman collection
- **#24** — Mouser product-search backend + frontend (mirrors #20's DigiKey pattern)
- **#27** (sub-issue of #24) — rename `web/search.html` → `web/digikey-search.html` for naming symmetry

Two commits stack on `origin/main`:

| Commit | Issues | What |
|---|---|---|
| `34324be` | #25 | Mouser Postman collection JSON + YAML mirror under `api/mouser/` and `postman/collections/Mouser API/` |
| `5e2c706` | #24, #27 | Mouser FastAPI backend, `mouser-search.html`, homepage two-link nav, DigiKey page rename, TEST-PLAN.md updates |

### Architecture (same shape as the DigiKey #20 backend)

```
web/mouser-search.html ──fetch──▶ FastAPI @ :8001 ──HTTPS──▶ api.mouser.com
   (static)                       api/mouser/server/         /api/v1/search/partnumber
                                  • reads MOUSER_API_KEY from .env
                                  • no token cache (per-request apiKey query string)
```

Mouser backend on **port 8001** (DigiKey on 8000) so both can run side by side. The frontend's `BACKEND_URL` is a single JS constant for a future migration to a hosted serverless function.

### Mouser-specific handling

- Multiple `Parts[]` matches → pick by exact `ManufacturerPartNumber` (case-insensitive), else first
- `PriceBreaks[].Price` arrives as a string like `"$0.51"` or `"0.51"` → strip currency symbol and `float()`, tolerating comma-as-decimal locales
- Body-level `Errors[]` surfaced as HTTP 502s

### What was verified

- **#25 Postman files** — user imported into Postman and confirmed live API responses with their real `MOUSER_API_KEY`
- **#24 Mouser backend** — Python files are well-formed and follow the DigiKey backend's structure verbatim. **Live end-to-end smoke test not run from this branch** (the user has a Mouser API key in Postman but no `.env` populated in `api/mouser/server/`). Risk: the `_parse_price` string-stripping logic for `Price` field is the one bit not validated against a real API response. Recommended pre-merge: populate `api/mouser/server/.env` with `MOUSER_API_KEY=...`, run `uvicorn main:app --port 8001`, `curl 'http://localhost:8001/pricing?manufacturer_part_number=NE555P'`.
- **#27 rename** — straightforward `git mv` + downstream link updates; all references swept via grep

### URL-stability note (#27)

After merge, `https://wongvin.github.io/firstcontact/search.html` will 404. The only known link was the homepage anchor (now updated). No redirect added — GH Pages doesn't support server-side redirects without a build step.

### Test plan (for the reviewer)

- [ ] Pull this branch locally
- [ ] `cp api/mouser/server/.env.example api/mouser/server/.env`, fill in `MOUSER_API_KEY`
- [ ] Reuse the DigiKey venv: `source api/digikey/server/.venv/bin/activate` (same deps)
- [ ] `cd api/mouser/server && uvicorn main:app --port 8001`
- [ ] In another terminal:
  ```
  curl http://localhost:8001/health
  curl 'http://localhost:8001/pricing?manufacturer_part_number=NE555P'
  curl 'http://localhost:8001/pricing?manufacturer_part_number=NOTAPART_xyz'   # expect 502
  ```
  → Expect headline tier (`tiers[-2]`) returned with non-empty `tiers[]`, `currency`, `mouser_part_number`. Validate `unit_price` matches what Mouser's PriceBreaks say for that tier.
- [ ] `cd web && python3 -m http.server 8080`, open `http://localhost:8080/mouser-search.html`, search a known MPN; verify headline + caption render
- [ ] Open `http://localhost:8080/digikey-search.html` (renamed from `search.html`), verify it still works against the DigiKey backend on port 8000
- [ ] After GH Pages build picks up the merge, confirm `https://wongvin.github.io/firstcontact/` shows two stacked links bottom-right and `https://.../search.html` 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
