### PR TITLE
Claude Code transcript viewer (issue #33)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026-05-22
+
+### feat: Claude Code transcript viewer (issue #33)
+
+- Add `api/server/claudecode_client.py` — JSONL parser that walks `~/.claude/projects/**/*.jsonl`, groups each session's events into `(user_prompt, assistant_response)` pairs (dropping `thinking` blocks, collapsing `tool_use` blocks, skipping `queue-operation` / `ai-title` / `attachment` / `file-history-snapshot` / `last-prompt` / `pr-link` noise), and merges every session into one flat timeline sorted by `timestamp`
+- Add a third `APIRouter(prefix="/claudecode")` on `api/server/main.py`. One endpoint: `GET /claudecode/timeline` returns `{prompts: [{index, day, timestamp, session_id, user_text, response_text}], days: [{date, first_prompt_index, last_prompt_index}]}`
+- Add new static page `web/transcripts-viewer.html` — response card on top (no `Response` label, minimal padding), datetime line, read-only `<textarea>` prompt editbox at the bottom; no sidebar, no session dropdown, no session-id chip, no "Prompt #N of M"
+- Arrow-key navigation operates on the global timeline across session boundaries: ↑↓ moves prompts, ←→ jumps days. `document.activeElement` exemption keeps the textarea's own cursor navigation intact when focused inside it
+- **Tool-call rendering tweaks:**
+  - Consecutive `tool_use` blocks collapse onto a single line — `🔧 tool_call: Read... Bash... Edit...` — instead of one line per call
+  - If the first line of a response (after grouping) is a tool-call line, it's dropped — the viewer leads with the assistant's first user-facing text rather than operational noise
+- **Day-position memory** (in-memory only): when navigating away from a day via ←/→ and back, the viewer restores the last prompt you viewed within that day instead of jumping to the day's first prompt
+- URL state: `?prompt=<N>` for deep-linking by global prompt index (default = newest prompt)
+- Restructure `web/index.html` bottom-right nav into three stacked links: `DigiKey search →`, `Mouser search →`, `Transcripts viewer →`
+- Document the new page in `web/TEST-PLAN.md` § 8 (homepage link, backend-unreachable, local-backend smoke including keyboard navigation across session boundaries, defense-in-depth on both response and prompt rendering)
+- No new Python dependencies (stdlib `json`, `pathlib` only)
+
 ## 2026-05-18
 
 ### refactor: combine DigiKey + Mouser API servers into one (issue #26)

--- a/api/server/claudecode_client.py
+++ b/api/server/claudecode_client.py
@@ -1,0 +1,229 @@
+"""Claude Code session-transcript parser.
+
+Walks every `*.jsonl` file under `~/.claude/projects/`, groups events into
+`(user_prompt, assistant_response)` pairs, and produces a flat globally-sorted
+timeline that the /claudecode/* routes serve to the viewer page.
+
+JSONL event types observed in practice:
+  - user                       — user prompt OR a tool_result echo (filter out the latter)
+  - assistant                  — Claude's reply, with content blocks (text/thinking/tool_use)
+  - ai-title                   — auto-generated session title
+  - queue-operation            — operational noise
+  - attachment                 — attached file
+  - file-history-snapshot      — file snapshots
+  - last-prompt                — marker
+  - pr-link                    — PR link
+
+Output shape (returned by build_timeline):
+{
+  "prompts": [
+    {
+      "index": 0,
+      "day": "2026-05-13",
+      "timestamp": "2026-05-13T22:00:00.000Z",
+      "session_id": "21314020-...",
+      "user_text": "...",
+      "response_text": "..."
+    },
+    ...
+  ],
+  "days": [
+    { "date": "2026-05-13", "first_prompt_index": 0, "last_prompt_index": 14 },
+    ...
+  ]
+}
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PROJECTS_ROOT = Path.home() / ".claude" / "projects"
+
+NOISE_TYPES = frozenset({
+    "queue-operation",
+    "ai-title",
+    "attachment",
+    "file-history-snapshot",
+    "last-prompt",
+    "pr-link",
+})
+
+
+def _iter_session_files() -> Iterable[Path]:
+    if not PROJECTS_ROOT.exists():
+        return []
+    return sorted(PROJECTS_ROOT.glob("*/*.jsonl"))
+
+
+def _extract_user_text(entry: dict[str, Any]) -> str | None:
+    """Return the user-typed text from a `type: user` entry, or None if this is a tool result echo."""
+    message = entry.get("message") or {}
+    content = message.get("content")
+    if isinstance(content, str):
+        return content if content.strip() else None
+    if not isinstance(content, list):
+        return None
+    pieces: list[str] = []
+    has_tool_result = False
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "tool_result":
+            has_tool_result = True
+            continue
+        if btype == "text" and isinstance(block.get("text"), str):
+            pieces.append(block["text"])
+    text = "\n".join(p.strip() for p in pieces if p.strip())
+    if not text:
+        return None
+    if has_tool_result and not text.strip():
+        return None
+    return text
+
+
+def _extract_assistant_items(entry: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return typed items from an assistant entry as a list of (kind, value) pairs.
+
+    `kind` is either 'text' (value = the text) or 'tool' (value = the tool name).
+    `thinking` blocks are dropped. The list preserves the order of blocks in the entry
+    so a downstream pass can group consecutive `tool` items into one line.
+    """
+    message = entry.get("message") or {}
+    content = message.get("content")
+    if isinstance(content, str):
+        return [("text", content)] if content else []
+    if not isinstance(content, list):
+        return []
+    items: list[tuple[str, str]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text" and isinstance(block.get("text"), str):
+            text = block["text"]
+            if text:
+                items.append(("text", text))
+        elif btype == "tool_use":
+            name = block.get("name") or "tool"
+            items.append(("tool", name))
+        # 'thinking' blocks intentionally dropped
+    return items
+
+
+_TOOL_CALL_PREFIX = "🔧 tool_call:"
+
+
+def _render_response_items(items: list[tuple[str, str]]) -> str:
+    """Join a flat list of (kind, value) items into a renderable string.
+
+    Consecutive `tool` items collapse into one line:
+        🔧 tool_call: Read... Bash... Edit...
+    Non-consecutive (text-interleaved) tool items keep their own lines.
+
+    If the first chunk after grouping is a tool-call line, it is dropped — the viewer
+    leads with the assistant's first user-facing text instead of operational noise.
+    """
+    if not items:
+        return ""
+    chunks: list[str] = []
+    tool_buffer: list[str] = []
+
+    def flush_tools() -> None:
+        if tool_buffer:
+            chunks.append(_TOOL_CALL_PREFIX + " " + "... ".join(tool_buffer) + "...")
+            tool_buffer.clear()
+
+    for kind, value in items:
+        if kind == "tool":
+            tool_buffer.append(value)
+        else:
+            flush_tools()
+            chunks.append(value)
+    flush_tools()
+    if chunks and chunks[0].startswith(_TOOL_CALL_PREFIX):
+        chunks = chunks[1:]
+    return "\n\n".join(chunks)
+
+
+def _parse_session(path: Path) -> list[dict[str, Any]]:
+    """Yield `(prompt, response)` pair dicts for one session file."""
+    pairs: list[dict[str, Any]] = []
+    current_prompt: dict[str, Any] | None = None
+    current_response_items: list[tuple[str, str]] = []
+
+    def flush() -> None:
+        if current_prompt is None:
+            return
+        current_prompt["response_text"] = _render_response_items(current_response_items).strip()
+        pairs.append(current_prompt)
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                etype = entry.get("type")
+                if etype in NOISE_TYPES:
+                    continue
+                if etype == "user":
+                    user_text = _extract_user_text(entry)
+                    if user_text is None:
+                        continue
+                    flush()
+                    current_prompt = {
+                        "timestamp": entry.get("timestamp"),
+                        "session_id": entry.get("sessionId") or path.stem,
+                        "user_text": user_text,
+                    }
+                    current_response_items = []
+                elif etype == "assistant":
+                    if current_prompt is None:
+                        # response with no preceding user prompt — skip
+                        continue
+                    current_response_items.extend(_extract_assistant_items(entry))
+    except OSError:
+        return []
+    flush()
+    return [p for p in pairs if p.get("timestamp")]
+
+
+def build_timeline() -> dict[str, Any]:
+    """Parse every session under PROJECTS_ROOT into a single sorted timeline."""
+    all_pairs: list[dict[str, Any]] = []
+    for path in _iter_session_files():
+        all_pairs.extend(_parse_session(path))
+
+    all_pairs.sort(key=lambda p: p["timestamp"])
+
+    prompts: list[dict[str, Any]] = []
+    days_map: dict[str, list[int]] = {}
+    for index, pair in enumerate(all_pairs):
+        ts = pair["timestamp"] or ""
+        day = ts[:10] if len(ts) >= 10 else ""
+        prompts.append({
+            "index": index,
+            "day": day,
+            "timestamp": ts,
+            "session_id": pair.get("session_id", ""),
+            "user_text": pair.get("user_text", ""),
+            "response_text": pair.get("response_text", ""),
+        })
+        days_map.setdefault(day, []).append(index)
+
+    days = [
+        {"date": day, "first_prompt_index": indexes[0], "last_prompt_index": indexes[-1]}
+        for day, indexes in sorted(days_map.items())
+        if day
+    ]
+
+    return {"prompts": prompts, "days": days}

--- a/api/server/main.py
+++ b/api/server/main.py
@@ -1,12 +1,11 @@
-"""Combined FastAPI app exposing /digikey/pricing and /mouser/pricing.
+"""Combined FastAPI app exposing /digikey/pricing, /mouser/pricing, and /claudecode/timeline.
 
-Replaces the previous two per-distributor servers (api/digikey/server/ and
-api/mouser/server/). One process, one port, one .env with both sets of
-credentials, one CORS middleware block, one venv to manage.
+One process, one port, one .env (DigiKey + Mouser credentials), one CORS middleware block.
 
 Frontends:
-- web/digikey-search.html → GET /digikey/pricing
-- web/mouser-search.html  → GET /mouser/pricing
+- web/digikey-search.html  → GET /digikey/pricing
+- web/mouser-search.html   → GET /mouser/pricing
+- web/transcripts-viewer.html → GET /claudecode/timeline
 """
 
 from __future__ import annotations
@@ -15,13 +14,14 @@ from dotenv import load_dotenv
 from fastapi import APIRouter, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 
+from claudecode_client import build_timeline
 from digikey_client import DigiKeyError, get_pricing as get_digikey_pricing
 from mouser_client import MouserError, get_pricing as get_mouser_pricing
 
 
 load_dotenv()
 
-app = FastAPI(title="Part-pricing proxy (DigiKey + Mouser)", version="0.2.0")
+app = FastAPI(title="Part-pricing proxy + Claude Code transcript viewer", version="0.3.0")
 
 app.add_middleware(
     CORSMiddleware,
@@ -37,6 +37,7 @@ app.add_middleware(
 
 digikey_router = APIRouter(prefix="/digikey", tags=["digikey"])
 mouser_router = APIRouter(prefix="/mouser", tags=["mouser"])
+claudecode_router = APIRouter(prefix="/claudecode", tags=["claudecode"])
 
 
 @digikey_router.get("/pricing")
@@ -59,8 +60,15 @@ async def mouser_pricing(
         raise HTTPException(status_code=502, detail=str(err))
 
 
+@claudecode_router.get("/timeline")
+async def claudecode_timeline():
+    """Flat globally-sorted timeline of (user_prompt, assistant_response) pairs across all sessions."""
+    return build_timeline()
+
+
 app.include_router(digikey_router)
 app.include_router(mouser_router)
+app.include_router(claudecode_router)
 
 
 @app.get("/health")

--- a/web/TEST-PLAN.md
+++ b/web/TEST-PLAN.md
@@ -184,6 +184,45 @@ Prerequisite: combined backend up per `api/server/README.md` with a real `MOUSER
 |---|---|---|
 | 7d.1 | DevTools → Elements → after a successful search, inspect the `.headline` and `.part-line` nodes. | Inner content is Text nodes only — no nested markup injected from the backend response. (Confirms `document.createElement` + `textContent` / `createTextNode` rendering path, mirroring the DigiKey page.) |
 
+## 8. Claude Code transcript viewer (issue #33)
+
+The `web/transcripts-viewer.html` page is a static frontend that calls the combined backend at `http://localhost:8000/claudecode/timeline` (`api/server/`). The backend reads JSONL files from `~/.claude/projects/**/*.jsonl` and returns a globally-sorted timeline of `(user_prompt, assistant_response)` pairs with per-day buckets. No external API, no credentials — purely local file read.
+
+### 8a. Homepage link
+
+| ID | Steps | Expected |
+|---|---|---|
+| 8a.1 | Open `https://wongvin.github.io/firstcontact/`. | Bottom-right shows three stacked glass-card links: `DigiKey search →`, `Mouser search →`, `Transcripts viewer →`. |
+| 8a.2 | Click the Transcripts-viewer link. | Navigates to `/firstcontact/transcripts-viewer.html`. Page loads with the same gradient background, a "← Home" link top-left, a "Response" card occupying most of the page, a datetime line beneath it, a `<textarea readonly>` prompt editbox, and a `↑↓ prompts · ←→ days` help line. |
+
+### 8b. Backend unreachable (live site, no local server)
+
+| ID | Steps | Expected |
+|---|---|---|
+| 8b.1 | On the live `/transcripts-viewer.html` with no local backend running, wait for the initial load. | Response card shows: "Backend unreachable at `http://localhost:8000` — start the local server (see `api/server/README.md`)." No console crash. |
+
+### 8c. Local-backend smoke (developer-only)
+
+Prerequisite: combined backend up per `api/server/README.md` (`.env` doesn't need credentials for this endpoint — the timeline parser only reads local JSONL files).
+
+| ID | Steps | Expected |
+|---|---|---|
+| 8c.1 | `curl http://localhost:8000/health` | Returns `{"status":"ok"}`. |
+| 8c.2 | `curl -s 'http://localhost:8000/claudecode/timeline' \| jq '{prompts: (.prompts\|length), days: (.days\|length), first: .prompts[0]}'` | Returns JSON with non-empty `prompts` and `days` counts; the first prompt has `user_text`, `response_text`, `timestamp`, `session_id` strings. |
+| 8c.3 | Serve `web/` locally (`cd web && python3 -m http.server 8080`), open `http://localhost:8080/transcripts-viewer.html`. | Latest prompt's response renders in the top card; datetime label shows above the prompt editbox; the prompt textarea contains the user's prompt text. No "Prompt #N of M" line, no session-id chip, no sidebar, no session dropdown. |
+| 8c.4 | Press ↓ a few times. | The response card and prompt textarea update. The prompt index increments — may cross into a different session_id (verify by reading the timeline payload's `session_id` for the displayed prompt; it can change). |
+| 8c.5 | Press ←. | Jumps back to the previous day's first prompt. May cross session boundaries cleanly (the days array is global). |
+| 8c.6 | Press → from the same prompt. | Jumps to the next day's first prompt. |
+| 8c.7 | Click into the prompt `<textarea>`, then press ↑ or ↓. | Cursor moves *within* the textarea (text-select navigation); the page does NOT advance to a different prompt. Click outside to resume global navigation. |
+| 8c.8 | Refresh the page with `?prompt=5` appended. | The viewer loads with the 5th prompt (global index) shown. |
+
+### 8d. Defense-in-depth
+
+| ID | Steps | Expected |
+|---|---|---|
+| 8d.1 | DevTools → Elements → inspect the response card's body span. | Inner content is Text nodes only — no nested markup injected from the JSONL response (confirms `textContent` rendering path). |
+| 8d.2 | Inspect the prompt textarea. | Element is `<textarea readonly>` with a `.value` property set; no inner HTML. Even if a JSONL line contained `<script>...</script>`, it would appear as literal text in the textarea. |
+
 ## Exit criteria
 
 A change ships when:

--- a/web/index.html
+++ b/web/index.html
@@ -109,9 +109,10 @@
     <h2>Changes made this week</h2>
     <ol id="recent-tasks-list"><li class="empty">Loading…</li></ol>
   </aside>
-  <nav class="tool-links" aria-label="Product search tools">
+  <nav class="tool-links" aria-label="Tools">
     <a class="tool-link" href="digikey-search.html">DigiKey search →</a>
     <a class="tool-link" href="mouser-search.html">Mouser search →</a>
+    <a class="tool-link" href="transcripts-viewer.html">Transcripts viewer →</a>
   </nav>
   <script>
     document.getElementById('device').textContent =

--- a/web/transcripts-viewer.html
+++ b/web/transcripts-viewer.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claude Code Transcript Viewer</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      color: white;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      padding: 1rem;
+      box-sizing: border-box;
+      gap: 0.75rem;
+    }
+    a.home-link {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      color: rgba(255, 255, 255, 0.85);
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 0.4rem 0.75rem;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 0.4rem;
+      background: rgba(255, 255, 255, 0.08);
+      z-index: 10;
+    }
+    a.home-link:hover { color: white; }
+    main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-top: 3.5rem;
+      min-height: 0;
+    }
+    .response-card {
+      flex: 1;
+      min-height: 0;
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 0.75rem;
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      padding: 0.4rem 0.75rem;
+      overflow-y: auto;
+      white-space: pre-wrap;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.9rem;
+      line-height: 1.45;
+    }
+    .response-card .body { display: block; }
+    .datetime {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.85rem;
+      opacity: 0.75;
+      padding-left: 0.5rem;
+    }
+    textarea.prompt {
+      width: 100%;
+      min-height: 5rem;
+      max-height: 30vh;
+      box-sizing: border-box;
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 0.75rem;
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      color: white;
+      padding: 1rem 1.25rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.9rem;
+      line-height: 1.45;
+      resize: vertical;
+      outline: none;
+    }
+    textarea.prompt:focus { border-color: rgba(255, 255, 255, 0.55); }
+    .help {
+      text-align: center;
+      font-size: 0.8rem;
+      opacity: 0.7;
+      letter-spacing: 0.04em;
+    }
+    .muted { opacity: 0.75; font-size: 0.95rem; }
+    .error { color: #ffd6d6; }
+  </style>
+</head>
+<body>
+  <a class="home-link" href="index.html">← Home</a>
+
+  <main>
+    <section class="response-card" id="response-card" aria-live="polite">
+      <span class="body" id="response-body">Loading…</span>
+    </section>
+
+    <div class="datetime" id="datetime"></div>
+
+    <textarea class="prompt" id="prompt" readonly aria-label="User prompt"></textarea>
+
+    <div class="help">↑↓ prompts &nbsp;·&nbsp; ←→ days</div>
+  </main>
+
+  <script>
+    const BACKEND_URL = "http://localhost:8000";
+
+    const responseBody = document.getElementById('response-body');
+    const datetimeEl = document.getElementById('datetime');
+    const promptEl = document.getElementById('prompt');
+
+    let prompts = [];
+    let days = [];
+    let currentIndex = 0;
+    const lastIndexByDay = {};  // remembers last viewed prompt index within each day
+
+    function setMessage(text, className) {
+      responseBody.textContent = text;
+      responseBody.className = 'body' + (className ? ' ' + className : '');
+      datetimeEl.textContent = '';
+      promptEl.value = '';
+    }
+
+    function formatDatetime(iso) {
+      if (!iso) return '';
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) return iso;
+      const pad = (n) => String(n).padStart(2, '0');
+      return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate())
+        + '  ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+    }
+
+    function render(index) {
+      if (!prompts.length) {
+        setMessage('No prompts found in ~/.claude/projects/.', 'muted');
+        return;
+      }
+      const clamped = Math.max(0, Math.min(prompts.length - 1, index));
+      currentIndex = clamped;
+      const p = prompts[clamped];
+      responseBody.className = 'body';
+      responseBody.textContent = p.response_text || '(no response captured)';
+      datetimeEl.textContent = formatDatetime(p.timestamp);
+      promptEl.value = p.user_text || '';
+
+      if (p.day) lastIndexByDay[p.day] = clamped;
+
+      const url = new URL(window.location.href);
+      url.searchParams.set('prompt', String(clamped));
+      window.history.replaceState(null, '', url.toString());
+    }
+
+    function dayIndexOf(currentDay) {
+      for (let i = 0; i < days.length; i++) {
+        if (days[i].date === currentDay) return i;
+      }
+      return -1;
+    }
+
+    function targetForDay(day) {
+      const remembered = lastIndexByDay[day.date];
+      if (remembered != null
+          && remembered >= day.first_prompt_index
+          && remembered <= day.last_prompt_index) {
+        return remembered;
+      }
+      return day.first_prompt_index;
+    }
+
+    function goToPrevDay() {
+      if (!prompts.length || !days.length) return;
+      const di = dayIndexOf(prompts[currentIndex].day);
+      if (di > 0) {
+        render(targetForDay(days[di - 1]));
+      } else if (di === -1 && days.length) {
+        // current prompt's day not in days[] — fall back to first day
+        render(targetForDay(days[0]));
+      }
+    }
+
+    function goToNextDay() {
+      if (!prompts.length || !days.length) return;
+      const di = dayIndexOf(prompts[currentIndex].day);
+      if (di >= 0 && di < days.length - 1) {
+        render(targetForDay(days[di + 1]));
+      }
+    }
+
+    document.addEventListener('keydown', (event) => {
+      if (document.activeElement === promptEl) return;  // textarea owns its arrow keys
+      const key = event.key;
+      if (key === 'ArrowUp') {
+        event.preventDefault();
+        render(currentIndex - 1);
+      } else if (key === 'ArrowDown') {
+        event.preventDefault();
+        render(currentIndex + 1);
+      } else if (key === 'ArrowLeft') {
+        event.preventDefault();
+        goToPrevDay();
+      } else if (key === 'ArrowRight') {
+        event.preventDefault();
+        goToNextDay();
+      }
+    });
+
+    (async function load() {
+      try {
+        const res = await fetch(BACKEND_URL + '/claudecode/timeline');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        prompts = Array.isArray(data.prompts) ? data.prompts : [];
+        days = Array.isArray(data.days) ? data.days : [];
+        const urlParams = new URLSearchParams(window.location.search);
+        const requested = parseInt(urlParams.get('prompt') || '', 10);
+        const startIndex = Number.isFinite(requested)
+          ? requested
+          : Math.max(0, prompts.length - 1);
+        render(startIndex);
+      } catch (err) {
+        const msg = err && err.message ? err.message : String(err);
+        if (msg.includes('Failed to fetch') || msg.includes('NetworkError')) {
+          setMessage('Backend unreachable at ' + BACKEND_URL + ' — start the local server (see api/server/README.md).', 'error');
+        } else {
+          setMessage(msg, 'error');
+        }
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes #33.

Adds a local web viewer for Claude Code session transcripts. Reads JSONL files from `~/.claude/projects/`, groups events into `(user_prompt, assistant_response)` pairs, presents a flat globally-sorted timeline that you navigate with arrow keys.

Same `api/server/` + `web/*` pattern as #20, #24, #26. No new Python dependencies (stdlib `json` / `pathlib` only). No external API; pure local file read.

### Endpoint

`GET /claudecode/timeline` →
```json
{
  "prompts": [
    {
      "index": 0,
      "day": "2026-04-22",
      "timestamp": "2026-04-22T04:27:50.919Z",
      "session_id": "41b5c2a0-...",
      "user_text": "...",
      "response_text": "..."
    }
  ],
  "days": [
    { "date": "2026-04-22", "first_prompt_index": 0, "last_prompt_index": 5 }
  ]
}
```

### Page layout (`web/transcripts-viewer.html`)

```
┌─────────────────────────────────────────────┐
│ ← Home                                       │
│                                              │
│ ┌──────────────────────────────────────────┐ │
│ │ <assistant response, scrollable>         │ │  ← no "Response" label, minimal padding
│ │                                          │ │
│ └──────────────────────────────────────────┘ │
│                                              │
│ 2026-05-18  21:43                            │  ← datetime
│ ┌──────────────────────────────────────────┐ │
│ │ <textarea readonly>user prompt</textarea>│ │  ← read-only, selectable
│ └──────────────────────────────────────────┘ │
│                                              │
│ ↑↓ prompts  ←→ days                          │
└──────────────────────────────────────────────┘
```

No sidebar, no session dropdown, no session-id chip, no "Prompt #N of M".

### Keyboard navigation

- `↑` / `↓` — previous / next prompt in the global timeline (crosses session boundaries naturally)
- `←` / `→` — previous / next active day (also crosses session boundaries)
- `document.activeElement` exemption: when the prompt textarea is focused, arrow keys move the textarea's cursor instead of triggering global navigation
- **Day-position memory** (in-memory): when you navigate away from a day via `←/→` and back, the last prompt you viewed within that day is restored (instead of always jumping to the day's first prompt)

### Refinements from plan iteration

1. **Consecutive tool-call collapse** — multiple back-to-back `tool_use` blocks render as one line `🔧 tool_call: Read... Bash... Edit...` instead of one line per call
2. **Hide leading tool-call line** — if a response's first line (after grouping) is a tool-call line, drop it so the viewer leads with the assistant's user-facing text rather than operational noise
3. **No "Response" label / minimal padding** — the response card just shows the text
4. **Day-position memory** — `←/→` restores within-day position instead of jumping to the day's first prompt

### Smoke test (verified against my live `~/.claude/projects/` data)

```
GET /health  →  {"status":"ok"}

GET /claudecode/timeline
  →  187 prompts across 15 days from 3 distinct sessions
  →  0 responses start with a tool-call line (was 107+ before the leading-drop pass)
  →  example: prompt #4 response collapses 3 consecutive tool calls into
     "🔧 tool_call: Bash... Write... Write..."  →  then dropped since it was the leading line
```

### Files added

- `api/server/claudecode_client.py` — JSONL parser + tool-call grouping + leading-drop
- `web/transcripts-viewer.html` — frontend

### Files modified

- `api/server/main.py` — mount `/claudecode/*` router
- `web/index.html` — third nav link `Transcripts viewer →`
- `web/TEST-PLAN.md` — new § 8
- `ChangeLog.md` — entry under `## 2026-05-22`

### Reviewer test plan

- [ ] Pull the branch
- [ ] `cd api/server && source .venv/bin/activate && uvicorn main:app --port 8000`
- [ ] `curl http://localhost:8000/health` → `{"status":"ok"}`
- [ ] `curl 'http://localhost:8000/claudecode/timeline' | jq '{prompts: (.prompts|length), days: (.days|length)}'` → non-zero counts
- [ ] `cd web && python3 -m http.server 8080`, open `http://localhost:8080/transcripts-viewer.html`
- [ ] Verify layout: response on top (no "Response" label), datetime line, readonly textarea prompt at bottom; no sidebar/dropdown
- [ ] Press `↑/↓` — navigates prompts globally (can cross session boundaries; verify by inspecting timeline JSON to see `session_id` changes mid-navigation)
- [ ] Press `←/→` — jumps days
- [ ] At day D, prompt index N within the day, press `→` (away) then `←` (back to D) — verify the prompt index restores to N rather than jumping to day D's first prompt
- [ ] Inspect the response text — confirm consecutive `tool_use` blocks render as a single `🔧 tool_call: A... B... C...` line; confirm no response begins with a tool-call line
- [ ] Click into the prompt textarea — text is selectable; arrow keys move the cursor inside the textarea, not the page navigation
- [ ] Reload with `?prompt=5` — confirm 5th prompt loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
