### PR TITLE
docs(infra): adopt Claude insights suggestions (#36)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *.md) npx --yes markdownlint-cli2 --fix \"$f\" 2>/dev/null || true ;; esac; done"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: cleanup-branches
+description: Find merged local branches and delete both local + remote copies, preserving any branch tied to a Rejected issue per CLAUDE.md.
+---
+
+Follow this sequence to clean up branches:
+
+1. Run `git fetch --prune` to drop stale remote refs.
+2. Run `git branch --merged main` to list local branches fully merged into main; exclude `main` itself from the candidate set.
+3. For each candidate, check whether it is tied to a Rejected issue. The convention is that rejected branch names start with the issue number (e.g. `12-add-pull-to-refresh`) and the corresponding issue title is prefixed with `[Rejected] `. Cross-check with:
+   ```bash
+   gh issue list --state all --search '[Rejected] in:title' --json number,title
+   ```
+   Skip any branch whose leading number matches a Rejected issue — do not delete locally or remotely.
+4. For the remaining candidates, show the user the proposed delete list and wait for explicit yes/no before running:
+   ```bash
+   git branch -d <name>
+   git push origin --delete <name>
+   ```
+5. If a branch fails `git branch -d` because it's unmerged, do NOT use `-D` automatically. Stop and ask the user.
+
+Report what was deleted, what was skipped (and why), and what needed user attention.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ship
+description: Commit staged changes, push to origin, and close any "Closes #N" issues with an implementation summary. The user invoking /ship IS the explicit commit consent CLAUDE.md normally gates on.
+---
+
+`/ship` is the explicit user consent for the commit+push step that CLAUDE.md
+normally gates on. Run this sequence:
+
+1. Show `git status` and `git diff --staged` so the user sees what's about to ship.
+2. Check that `ChangeLog.md` is staged. If not, ask the user for a one-line
+   summary and add an entry under today's date heading with the matching
+   conventional prefix (`feat:`, `fix:`, `docs:`, …).
+3. Write the commit using a HEREDOC commit message — never inline — so backticks
+   and parentheses parse correctly:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   <conventional prefix>: <summary>
+
+   <body>
+
+   Closes #N
+   EOF
+   )"
+   ```
+4. `git push` to origin.
+5. For each `Closes #N` referenced in the commit body, post an
+   implementation-summary comment via heredoc stdin:
+   ```bash
+   gh issue comment N --body-file - <<'EOF'
+   <summary covering: files changed, key code pieces, verification done.
+   Skip ChangeLog noise — focus on the functional change.>
+   EOF
+   ```
+   The issue itself closes automatically because of the `Closes #N` in the
+   commit (GitHub's "linked PR/commit closes issue" behavior). Project board
+   automation moves it to Done.
+6. Report the commit SHA, push result, and which issues were closed.
+
+Rules:
+
+- Never `--no-verify`.
+- Never bypass the heredoc commit-message path — inline `-m` mangles
+  backticks/parens.
+- Don't delete branches as part of `/ship` — that's `/cleanup-branches`.
+- If `Closes #N` references the wrong issue or there are none, ask the user
+  before posting anything to issues.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,12 +56,13 @@ When implementation begins on an issue:
 When implementation is complete and the diff is ready for commit:
 
 3. Move status from In progress → **In review**.
-4. Pause for explicit user consent before staging, committing, or pushing (see Commit hygiene below).
+4. Post an **implementation-summary comment on the issue** (via `gh issue comment N --body-file -` heredoc) so the user can review it on github.com — covering files changed, key code pieces, and verification done. Same content as the eventual close comment, posted earlier for review.
+5. Pause for explicit user consent before staging, committing, or pushing (see Commit hygiene below). The user reviews the comment on the issue, not just in chat.
 
 When an issue is rejected (declined outright, or implementation tried but not merged):
 
-5. Move status to **Rejected**.
-6. Prefix the issue title with `[Rejected] ` (e.g. `[Rejected] Add pull-to-refresh to iOS app`) so the rejection is visible outside the board view — `gh issue list`, cross-references, and the issues page.
+6. Move status to **Rejected**.
+7. Prefix the issue title with `[Rejected] ` (e.g. `[Rejected] Add pull-to-refresh to iOS app`) so the rejection is visible outside the board view — `gh issue list`, cross-references, and the issues page.
 
 Both the status transition and the Start date can be set from the GitHub UI (project board → click the item → fields panel on the right) or via the `gh` CLI:
 
@@ -88,6 +89,21 @@ gh project item-edit --id "$ITEM_ID" --field-id "$START_DATE_FIELD" \
 The CLI path requires the `project` scope on your `gh` token. The default
 `read:project` scope is read-only and insufficient for writes; refresh with
 `gh auth refresh -s project` once if you hit a scope error.
+
+### Branching
+
+Every issue's implementation lives on its own feature branch — never accumulate
+feature work directly on `main`. Create the branch **before** the first edit,
+not after:
+
+```bash
+git checkout main && git pull
+git checkout -b <issue-number>-<short-slug>
+```
+
+Naming convention: `<issue-number>-<short-slug>` (e.g. `33-transcript-viewer`,
+`36-claude-insights-suggestions`). Match the existing branches in
+`git branch -a` for style.
 
 ### Commit hygiene
 
@@ -119,3 +135,23 @@ long markdown bodies, post via `gh issue comment N --body-file -` with a
 stdin heredoc (avoids bash parse errors on backticks/quotes). The same
 `-F -` heredoc pattern is the safe form for `git commit` messages that
 contain shell metacharacters like parentheses.
+
+If closing as a duplicate, reference the canonical issue (e.g. "Duplicate of #N")
+in the close comment and skip the implementation summary.
+
+### Git branch cleanup
+
+When a branch's work has fully landed on `main` (merged PR, or closed-without-merge
+with the change applied), delete the branch **both locally and remotely**:
+
+```bash
+git branch -d <name>
+git push origin --delete <name>
+```
+
+Exceptions:
+
+- Any branch tied to a **Rejected** issue is preserved (see Status table) —
+  don't delete locally or remotely.
+- If the branch is unmerged and not Rejected, ask before force-deleting
+  (`git branch -D` or remote delete). Don't silently discard work.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-05-23
+
+### docs/infra: adopt Claude insights suggestions (issue #36)
+
+- `CLAUDE.md`: add `### Branching` section (feature branch before first edit, `<N>-<slug>` naming); add `### Git branch cleanup` section (delete local + remote after merge, preserve Rejected branches, ask before force-deleting unmerged); add duplicate-issue close rule to `### Closing issues`; add step 4 to `### Tracking active work` requiring a pre-commit implementation-summary issue comment for review on github.com
+- `.claude/skills/cleanup-branches/SKILL.md` — new `/cleanup-branches` skill: fetch-prune, list merged branches, cross-check against `[Rejected]` issues, pause before deletion
+- `.claude/skills/ship/SKILL.md` — new `/ship` skill: invocation is the explicit commit consent gate; runs status/diff review, ChangeLog check, heredoc commit, push, then heredoc implementation-summary close comments for `Closes #N` refs
+- `.claude/settings.json` — new committed post-edit hook: `markdownlint-cli2 --fix` runs only on the touched `.md` file via `$CLAUDE_FILE_PATHS`, not the whole tree
+- GitHub MCP server installed at user scope (run-once setup; auth via `gh auth token`)
+
 ## 2026-05-22
 
 ### feat: Claude Code transcript viewer (issue #33)


### PR DESCRIPTION
## Summary

- Add `### Branching`, `### Git branch cleanup` sections to `CLAUDE.md`; add step 4 to `### Tracking active work` (pre-commit implementation-summary issue comment); add duplicate-issue close bullet to `### Closing issues`.
- Add custom skills `/cleanup-branches` and `/ship` under `.claude/skills/`.
- Add committed `.claude/settings.json` with a `PostToolUse` markdownlint hook scoped to the touched `.md` file via `$CLAUDE_FILE_PATHS`.

Out of band (not in diff): GitHub MCP server installed at user scope with a `gh auth token` wrapper (no plaintext token at rest); Node v26 installed via brew for `npx`-launched MCP servers.

Full implementation summary on the issue: https://github.com/wongvin/firstcontact/issues/36#issuecomment-4527396082

Closes #36

## Test plan

- [x] `claude mcp list` → `github` shows ✓ Connected
- [x] CLAUDE.md renders cleanly; section numbering in "Tracking active work" is consistent (1–5 for In-progress→In-review path; 6–7 for the Rejected path)
- [x] `git diff --stat` confirms 5 files (2 modified, 3 new); `.claude/settings.local.json` remains gitignored
- [ ] After merge: start a new session and confirm `/cleanup-branches` and `/ship` appear in available skills
- [ ] After merge: edit any `.md` file and confirm the markdownlint hook fires only on that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)