### PR TITLE
Skill polish: /cleanup-branches origin/main + /ship subject (#38)

### DIFF
--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -6,7 +6,7 @@ description: Find merged local branches and delete both local + remote copies, p
 Follow this sequence to clean up branches:
 
 1. Run `git fetch --prune` to drop stale remote refs.
-2. Run `git branch --merged main` to list local branches fully merged into main; exclude `main` itself from the candidate set.
+2. Run `git branch --merged origin/main` to list local branches fully merged into the canonical remote main; exclude `main` itself from the candidate set. (Query the remote ref, not local `main`, because a PR merged on github.com doesn't fast-forward local `main` until the user runs `git pull` — checking local `main` would undercount candidates.)
 3. For each candidate, check whether it is tied to a Rejected issue. The convention is that rejected branch names start with the issue number (e.g. `12-add-pull-to-refresh`) and the corresponding issue title is prefixed with `[Rejected] `. Cross-check with:
    ```bash
    gh issue list --state all --search '[Rejected] in:title' --json number,title

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Commit staged changes, push to origin, and post an implementation-summary comment on the branch's issue. The user invoking /ship IS the explicit commit consent CLAUDE.md normally gates on.
+description: Commit staged changes, push to origin, post an implementation-summary comment on the branch's issue, and ensure a PR exists (creating one if needed). The user invoking /ship IS the explicit commit consent CLAUDE.md normally gates on.
 ---
 
 `/ship` is the explicit user consent for the commit+push step that CLAUDE.md
@@ -40,8 +40,27 @@ normally gates on. Run this sequence:
    multiple issues, ask the user which issues to comment on before posting.
    Closing the issue itself is handled separately (PR merge, or manual
    `gh issue close`) — `/ship` only posts the summary.
-6. Report the commit SHA, push result, and which issue(s) received a summary
-   comment.
+6. Ensure a PR exists for the branch and surface its URL:
+   ```bash
+   gh pr view --json url,state  # check first
+   ```
+   If no PR exists, create one against `main`. PR title follows the same
+   `<prefix>: <summary> (#N)` shape as the commit subject (single-commit
+   branch: reuse the commit subject; multi-commit branch: summarize across
+   commits). PR body should include a short summary and `Closes #N` so the
+   issue auto-closes on merge — this is the one place `Closes #N` is
+   allowed (PR body, not commit message):
+   ```bash
+   gh pr create --base main --title "<prefix>: <summary> (#N)" \
+     --body-file - <<'EOF'
+   <one-paragraph summary>
+
+   Closes #N
+   EOF
+   ```
+   Print the resulting URL so the user can click through.
+7. Report the commit SHA, push result, which issue(s) received a summary
+   comment, and the PR URL.
 
 Rules:
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Commit staged changes, push to origin, and close any "Closes #N" issues with an implementation summary. The user invoking /ship IS the explicit commit consent CLAUDE.md normally gates on.
+description: Commit staged changes, push to origin, and post an implementation-summary comment on the branch's issue. The user invoking /ship IS the explicit commit consent CLAUDE.md normally gates on.
 ---
 
 `/ship` is the explicit user consent for the commit+push step that CLAUDE.md
@@ -11,19 +11,24 @@ normally gates on. Run this sequence:
    summary and add an entry under today's date heading with the matching
    conventional prefix (`feat:`, `fix:`, `docs:`, …).
 3. Write the commit using a HEREDOC commit message — never inline — so backticks
-   and parentheses parse correctly:
+   and parentheses parse correctly. Append `(#N)` to the subject (for
+   multi-issue commits: `(#N, #M)`); do **not** add `Closes #N` or any other
+   `#N` reference in the body. **Keep the whole subject ≤50 chars** so the
+   trailing `(#N)` stays visible in `git log --oneline`, GitHub PR-title
+   fields, and other narrow UIs — if the summary is running long, tighten
+   the wording rather than letting the issue tag get clipped:
    ```bash
    git commit -m "$(cat <<'EOF'
-   <conventional prefix>: <summary>
+   <conventional prefix>: <summary> (#N)
 
    <body>
-
-   Closes #N
    EOF
    )"
    ```
+   If a heredoc fails to parse (rare, with certain shell environments),
+   fall back to `git commit -F <file>` after writing the message to a file.
 4. `git push` to origin.
-5. For each `Closes #N` referenced in the commit body, post an
+5. Derive the issue number from the branch name (`<N>-<slug>`) and post an
    implementation-summary comment via heredoc stdin:
    ```bash
    gh issue comment N --body-file - <<'EOF'
@@ -31,16 +36,21 @@ normally gates on. Run this sequence:
    Skip ChangeLog noise — focus on the functional change.>
    EOF
    ```
-   The issue itself closes automatically because of the `Closes #N` in the
-   commit (GitHub's "linked PR/commit closes issue" behavior). Project board
-   automation moves it to Done.
-6. Report the commit SHA, push result, and which issues were closed.
+   If the branch name doesn't match `<N>-<slug>`, or the commit addresses
+   multiple issues, ask the user which issues to comment on before posting.
+   Closing the issue itself is handled separately (PR merge, or manual
+   `gh issue close`) — `/ship` only posts the summary.
+6. Report the commit SHA, push result, and which issue(s) received a summary
+   comment.
 
 Rules:
 
 - Never `--no-verify`.
+- Never write `Closes #N` in the commit message. The subject's `(#N)` suffix
+  is the only `#N` reference; the body stays free of issue numbers. Closing
+  the issue happens elsewhere (PR body, manual `gh issue close`).
+- Subject budget ≤50 chars total (including the `(#N)` suffix) — if it spills,
+  shorten the summary, not the suffix.
 - Never bypass the heredoc commit-message path — inline `-m` mangles
   backticks/parens.
 - Don't delete branches as part of `/ship` — that's `/cleanup-branches`.
-- If `Closes #N` references the wrong issue or there are none, ask the user
-  before posting anything to issues.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-23
 
+### fix: /cleanup-branches checks origin/main instead of stale local main (issue #38)
+
+- `.claude/skills/cleanup-branches/SKILL.md` step 2: `git branch --merged origin/main` (was `--merged main`). Local `main` lags `origin/main` between a PR merge and the next `git pull`, so the previous form undercounted candidates immediately after a merge — hit during the #36 cleanup itself.
+
 ### docs/infra: adopt Claude insights suggestions (issue #36)
 
 - `CLAUDE.md`: add `### Branching` section (feature branch before first edit, `<N>-<slug>` naming); add `### Git branch cleanup` section (delete local + remote after merge, preserve Rejected branches, ask before force-deleting unmerged); add duplicate-issue close rule to `### Closing issues`; add step 4 to `### Tracking active work` requiring a pre-commit implementation-summary issue comment for review on github.com

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-23
 
+### docs(infra): refine /ship commit-subject convention (issue #38)
+
+- `.claude/skills/ship/SKILL.md`: subject template now `<prefix>: <summary> (#N)` with a ≤50-char total budget so the issue tag stays visible in narrow UIs (`git log --oneline`, GitHub PR titles); body must not contain `Closes #N` or other `#N` refs; implementation-summary comment trigger derives the issue number from the branch name (`<N>-<slug>`) instead of scanning the commit body for `Closes #N`.
+
 ### fix: /cleanup-branches checks origin/main instead of stale local main (issue #38)
 
 - `.claude/skills/cleanup-branches/SKILL.md` step 2: `git branch --merged origin/main` (was `--merged main`). Local `main` lags `origin/main` between a PR merge and the next `git pull`, so the previous form undercounted candidates immediately after a merge — hit during the #36 cleanup itself.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,10 @@
 
 ## 2026-05-23
 
-### docs(infra): refine /ship commit-subject convention (issue #38)
+### docs(infra): refine /ship skill conventions (issue #38)
 
-- `.claude/skills/ship/SKILL.md`: subject template now `<prefix>: <summary> (#N)` with a ≤50-char total budget so the issue tag stays visible in narrow UIs (`git log --oneline`, GitHub PR titles); body must not contain `Closes #N` or other `#N` refs; implementation-summary comment trigger derives the issue number from the branch name (`<N>-<slug>`) instead of scanning the commit body for `Closes #N`.
+- `.claude/skills/ship/SKILL.md` subject convention: template now `<prefix>: <summary> (#N)` with a ≤50-char total budget so the issue tag stays visible in narrow UIs (`git log --oneline`, GitHub PR titles); body must not contain `Closes #N` or other `#N` refs; implementation-summary comment trigger derives the issue number from the branch name (`<N>-<slug>`) instead of scanning the commit body for `Closes #N`.
+- `.claude/skills/ship/SKILL.md` PR step: new step 6 — after push and the issue comment, ensure a PR exists for the branch (create one with `gh pr create --base main` if missing) and surface the URL. PR body is the one place `Closes #N` is allowed, so the issue auto-closes on merge.
 
 ### fix: /cleanup-branches checks origin/main instead of stale local main (issue #38)
 


### PR DESCRIPTION
## Summary

Lumped-scope follow-up to issue #38, covering both the `/cleanup-branches` fix and a refresh of `/ship`'s conventions surfaced while shipping the first commit:

- **fix `/cleanup-branches`** (`40d7de1`): step 2 of `.claude/skills/cleanup-branches/SKILL.md` now queries `git branch --merged origin/main` instead of local `main`. Local `main` lags `origin/main` between a PR merge and the next `git pull`, so the previous form undercounted candidates — hit during the #36 cleanup itself.
- **`/ship` subject convention** (`539b078`): commit subject template is `<prefix>: <summary> (#N)` with a ≤50-char total budget so the `(#N)` tag stays visible in `git log --oneline`, GitHub PR-title fields, and other narrow UIs. `Closes #N` is banned from commit bodies. Implementation-summary comment trigger now derives the issue number from the branch name (`<N>-<slug>`).
- **`/ship` PR step** (`b2a6c58`): new step 6 ensures a GitHub PR exists for the branch (`gh pr create --base main` if missing) and surfaces the URL in the final report. PR body is the one place `Closes #N` is allowed — so the issue auto-closes on merge.

## Test plan

- [ ] Next `/ship` invocation produces a `<prefix>: <summary> (#N)` subject ≤50 chars with no `Closes #N` trailer.
- [ ] Next `/ship` invocation creates a PR (or surfaces the existing one) and prints its URL.
- [ ] Next `/cleanup-branches` invocation immediately after a PR merge finds the merged branch as a candidate without requiring an interim `git pull`.

Closes #38
