### PR TITLE
fix: /cleanup-branches current-branch delete (#40)

### DIFF
--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -12,8 +12,16 @@ Follow this sequence to clean up branches:
    gh issue list --state all --search '[Rejected] in:title' --json number,title
    ```
    Skip any branch whose leading number matches a Rejected issue — do not delete locally or remotely.
-4. For the remaining candidates, show the user the proposed delete list and wait for explicit yes/no before running:
+4. For the remaining candidates, show the user the proposed delete list and wait for explicit yes/no before running the deletes.
+
+   If a candidate is the currently-checked-out branch, switch to `main` and bring local `main` up to date with `origin/main` first — the delete will fail otherwise. Use `git merge --ff-only origin/main` (or the equivalent `git pull origin main`), **not** bare `git pull` / `git pull --ff-only`: the step-1 `git fetch --prune` leaves `.git/FETCH_HEAD` with multiple for-merge entries (one per fetched branch), and bare `pull` consults FETCH_HEAD and aborts with `fatal: Cannot fast-forward to multiple branches`. Specifying the source explicitly bypasses FETCH_HEAD.
+
    ```bash
+   # If the candidate is the current branch:
+   git checkout main
+   git merge --ff-only origin/main   # NOT `git pull` / `git pull --ff-only`
+
+   # Then for each candidate:
    git branch -d <name>
    git push origin --delete <name>
    ```

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-23
 
+### fix: /cleanup-branches handles current-branch delete (issue #40)
+
+- `.claude/skills/cleanup-branches/SKILL.md` step 4: when a candidate is the currently-checked-out branch, switch to `main` and fast-forward via `git merge --ff-only origin/main` (or equivalently `git pull origin main`) before the delete. Documented why bare `git pull` / `git pull --ff-only` fails here — the step-1 `git fetch --prune` leaves `.git/FETCH_HEAD` with multiple for-merge entries, so `pull` aborts with `fatal: Cannot fast-forward to multiple branches`; specifying the source explicitly bypasses FETCH_HEAD.
+
 ### docs(infra): refine /ship skill conventions (issue #38)
 
 - `.claude/skills/ship/SKILL.md` subject convention: template now `<prefix>: <summary> (#N)` with a ≤50-char total budget so the issue tag stays visible in narrow UIs (`git log --oneline`, GitHub PR titles); body must not contain `Closes #N` or other `#N` refs; implementation-summary comment trigger derives the issue number from the branch name (`<N>-<slug>`) instead of scanning the commit body for `Closes #N`.


### PR DESCRIPTION
## Summary

When `/cleanup-branches` runs and the merged candidate happens to be the currently-checked-out branch, the agent has to switch to `main` and bring local `main` up to date with `origin/main` before the delete. The skill text didn't say how, and the obvious `git pull --ff-only` fails because the step-1 `git fetch --prune` leaves `.git/FETCH_HEAD` with multiple for-merge entries.

Updates `.claude/skills/cleanup-branches/SKILL.md` step 4 to call out:

- switch to `main` + `git merge --ff-only origin/main` (or `git pull origin main`) — explicit source bypasses FETCH_HEAD;
- bare `git pull` / `git pull --ff-only` is the wrong form here, with a Why-note about the FETCH_HEAD ambiguity.

Hit during the #38 cleanup run, which is the trigger for this issue.

## Test plan

- [ ] Next `/cleanup-branches` invocation where the candidate is the current branch follows the new checkout + ff-only sequence and completes without `fatal: Cannot fast-forward to multiple branches`.
- [ ] An invocation where the candidate is **not** the current branch still works exactly as before (the new preamble is conditional).

Closes #40
