### PR TITLE
chore: auto-allow gh project item-edit (#42)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh project item-edit *)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-05-24
+
+### chore(infra): auto-allow gh project item-edit in committed settings (issue #42)
+
+- `.claude/settings.json`: added `Bash(gh project item-edit *)` to `permissions.allow`. The wildcard covers all four project-board transitions (Status → In progress / In review / Done, plus Start date), all of which run the same `gh project item-edit ...` shape with different `--single-select-option-id` or `--date` values. The rule already existed in the gitignored `.claude/settings.local.json` — promoting it makes the auto-allow apply for every contributor and every fresh checkout without manual local-settings tweaks.
+
 ## 2026-05-23
 
 ### fix: /cleanup-branches handles current-branch delete (issue #40)


### PR DESCRIPTION
## Summary

Adds `Bash(gh project item-edit *)` to `.claude/settings.json` `permissions.allow`. The wildcard covers all four project-board transition shapes Claude runs during normal issue work — Status → In progress / In review / Done, plus Start date — so every contributor's Claude session can run them without permission prompts.

The rule already existed in the gitignored `.claude/settings.local.json`; this just promotes it to the committed settings so it lives with the repo.

Split out from #35's commit per user request (the settings change was originally lumped in there; it deserves its own issue/PR).

## Test plan

- [ ] Fresh checkout: open Claude Code in this repo, ask it to move any issue's project-board status. No permission prompt for the `gh project item-edit ...` call.
- [ ] Existing `hooks` block (the markdownlint-cli2 PostToolUse on `Edit|Write`) still fires after edits to a `.md` file.

Closes #42
