### PR TITLE
chore(infra): gitignore graphify-out (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ __marimo__/
 
 # Postman local state
 .postman/
+
+# graphify outputs
+graphify-out/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-05-25
+
+### chore(infra): gitignore graphify-out (issue #46)
+
+- `.gitignore`: added `graphify-out/` so the local graph artifacts (`graph.html`, `graph.json`, `GRAPH_REPORT.md`, `cache/`, `manifest.json`, `cost.json`) produced by the `/graphify` skill stay out of the repo. Verified with `git check-ignore -v graphify-out/graph.html`.
+
 ## 2026-05-24
 
 ### feat: VIM search + cursor navigation in transcripts viewer (issue #45)


### PR DESCRIPTION
## Summary
- Adds `graphify-out/` to `.gitignore` so the local artifacts produced by the `/graphify` skill (`graph.html`, `graph.json`, `GRAPH_REPORT.md`, `cache/`, `manifest.json`, `cost.json`) stay out of the repo.
- ChangeLog entry under today's date.

## Test plan
- [x] `git check-ignore -v graphify-out/graph.html` confirms the new rule matches.

Closes #46
