### PR TITLE
chore(infra): backend port 8000→8001 (#58)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-05-29
+
+### chore(infra): move local backend port 8000 → 8001 (issue #58)
+
+- `web/transcripts-viewer.html`, `web/digikey-search.html`, `web/mouser-search.html`: `BACKEND_URL` constant updated from `http://localhost:8000` to `http://localhost:8001`. Port 8000 falls within Windows' WSL excluded-port range, so it isn't bindable for local development on a WSL host. 8001 is adjacent (easy to remember) and doesn't collide with 8080 used by the static `python -m http.server`.
+- `api/server/README.md`: `uvicorn main:app --port 8001` example + the "listens on http://localhost:8001" line + the two `curl` examples updated.
+- `web/TEST-PLAN.md`: 13 occurrences across § 6 (DigiKey), § 7 (Mouser), § 8 (Transcripts viewer) updated — curl examples, `Backend unreachable at http://localhost:8001` error-message expectations, and the `uvicorn main:app --port 8001` example in 7c.5.
+- No code changes in `api/server/main.py` — the backend reads its port from the uvicorn command-line flag; CORS `allow_origins` lists FRONTEND origins (5500 / 8080 / GH Pages), none of which are 8000.
+
 ## 2026-05-25
 
 ### feat: vim cross-response navigation (issue #50)

--- a/api/server/README.md
+++ b/api/server/README.md
@@ -21,10 +21,10 @@ pip install -r requirements.txt
 ## Run
 
 ```bash
-uvicorn main:app --port 8000
+uvicorn main:app --port 8001
 ```
 
-The server listens on `http://localhost:8000`. CORS is allowed for:
+The server listens on `http://localhost:8001`. CORS is allowed for:
 - `http://localhost:5500` (VS Code Live Server default)
 - `http://localhost:8080` (e.g. `python -m http.server 8080` from `web/`)
 - `https://wongvin.github.io` (the deployed GH Pages origin)
@@ -40,7 +40,7 @@ The server listens on `http://localhost:8000`. CORS is allowed for:
 ### `GET /digikey/pricing?manufacturer_part_number=<MPN>`
 
 ```bash
-curl 'http://localhost:8000/digikey/pricing?manufacturer_part_number=STM32F407VGT6'
+curl 'http://localhost:8001/digikey/pricing?manufacturer_part_number=STM32F407VGT6'
 ```
 
 Returns volume-tier pricing from DigiKey's ProductPricing v4 API. Picks the second-to-last tier as the headline.
@@ -48,7 +48,7 @@ Returns volume-tier pricing from DigiKey's ProductPricing v4 API. Picks the seco
 ### `GET /mouser/pricing?manufacturer_part_number=<MPN>`
 
 ```bash
-curl 'http://localhost:8000/mouser/pricing?manufacturer_part_number=NE555P'
+curl 'http://localhost:8001/mouser/pricing?manufacturer_part_number=NE555P'
 ```
 
 Returns volume-tier pricing from Mouser's V1 PartNumberSearch API. Same headline tier selection rule (`tiers[-2]`) for UX parity with the DigiKey route.

--- a/web/TEST-PLAN.md
+++ b/web/TEST-PLAN.md
@@ -117,7 +117,7 @@ This feature was originally a static day-of-year-rotating array (issue #2) and w
 
 ## 6. Product search (issue #20)
 
-The `web/digikey-search.html` page is a static frontend that calls a **local** Python FastAPI backend at `http://localhost:8000/digikey/...` (`api/server/`). The live deployed page exists but is non-functional unless the user has the combined backend running with their own DigiKey credentials. Since #26, the DigiKey and Mouser backends share one process — see § 7 for the Mouser-side smoke tests against the same server.
+The `web/digikey-search.html` page is a static frontend that calls a **local** Python FastAPI backend at `http://localhost:8001/digikey/...` (`api/server/`). The live deployed page exists but is non-functional unless the user has the combined backend running with their own DigiKey credentials. Since #26, the DigiKey and Mouser backends share one process — see § 7 for the Mouser-side smoke tests against the same server.
 
 ### 6a. Homepage link
 
@@ -130,7 +130,7 @@ The `web/digikey-search.html` page is a static frontend that calls a **local** P
 
 | ID | Steps | Expected |
 |---|---|---|
-| 6b.1 | On the live `/digikey-search.html` with no local backend running, type `STM32F407VGT6` and submit. | After a brief "Loading…", an error message appears: "Backend unreachable at `http://localhost:8000` — start the local server (see `api/server/README.md`)." Form re-enables; no console crash. |
+| 6b.1 | On the live `/digikey-search.html` with no local backend running, type `STM32F407VGT6` and submit. | After a brief "Loading…", an error message appears: "Backend unreachable at `http://localhost:8001` — start the local server (see `api/server/README.md`)." Form re-enables; no console crash. |
 
 ### 6c. Local backend smoke (developer-only)
 
@@ -138,8 +138,8 @@ Prerequisite: combined backend up per `api/server/README.md` with real `DIGIKEY_
 
 | ID | Steps | Expected |
 |---|---|---|
-| 6c.1 | `curl http://localhost:8000/health` | Returns `{"status":"ok"}`. |
-| 6c.2 | `curl 'http://localhost:8000/digikey/pricing?manufacturer_part_number=STM32F407VGT6'` | HTTP 200 with JSON containing `manufacturer_part_number`, `digikey_part_number`, `currency: "USD"`, non-empty `tiers` array (sorted ascending by `quantity`), and a `unit_price` / `tier_quantity` pair matching `tiers[-2]` (or `tiers[0]` if fewer than 2 entries). |
+| 6c.1 | `curl http://localhost:8001/health` | Returns `{"status":"ok"}`. |
+| 6c.2 | `curl 'http://localhost:8001/digikey/pricing?manufacturer_part_number=STM32F407VGT6'` | HTTP 200 with JSON containing `manufacturer_part_number`, `digikey_part_number`, `currency: "USD"`, non-empty `tiers` array (sorted ascending by `quantity`), and a `unit_price` / `tier_quantity` pair matching `tiers[-2]` (or `tiers[0]` if fewer than 2 entries). |
 | 6c.3 | Serve `web/` locally (`cd web && python -m http.server 8080`), open `http://localhost:8080/digikey-search.html`, type a known MPN, submit. | Headline renders as `Qty <N> → $<P> USD / unit` with both numbers in the same large font weight/size. A muted line below shows `<MPN>  ·  DK: <DigiKey-PN>`. No tier table appears. |
 | 6c.4 | Submit a bogus MPN like `NOTAPART_xyz`. | After "Loading…", an error message renders (DigiKey 404 surfaced as a 502 from the proxy with a "Part not found" detail), not the headline. |
 
@@ -151,7 +151,7 @@ Prerequisite: combined backend up per `api/server/README.md` with real `DIGIKEY_
 
 ## 7. Mouser product search (issue #24)
 
-The `web/mouser-search.html` page is a static frontend that calls a **local** Python FastAPI backend at `http://localhost:8000/mouser/...` (`api/server/`). Same shape as § 6 but for Mouser; since #26 both distributors share the single backend on port 8000, so § 6c and § 7c hit the same `uvicorn` process at different path prefixes.
+The `web/mouser-search.html` page is a static frontend that calls a **local** Python FastAPI backend at `http://localhost:8001/mouser/...` (`api/server/`). Same shape as § 6 but for Mouser; since #26 both distributors share the single backend on port 8001, so § 6c and § 7c hit the same `uvicorn` process at different path prefixes.
 
 ### 7a. Homepage link
 
@@ -164,7 +164,7 @@ The `web/mouser-search.html` page is a static frontend that calls a **local** Py
 
 | ID | Steps | Expected |
 |---|---|---|
-| 7b.1 | On the live `/mouser-search.html` with no local backend running, type `NE555P` and submit. | After a brief "Loading…", an error message appears: "Backend unreachable at `http://localhost:8000` — start the local server (see `api/server/README.md`)." Form re-enables; no console crash. |
+| 7b.1 | On the live `/mouser-search.html` with no local backend running, type `NE555P` and submit. | After a brief "Loading…", an error message appears: "Backend unreachable at `http://localhost:8001` — start the local server (see `api/server/README.md`)." Form re-enables; no console crash. |
 
 ### 7c. Local backend smoke (developer-only)
 
@@ -172,11 +172,11 @@ Prerequisite: combined backend up per `api/server/README.md` with a real `MOUSER
 
 | ID | Steps | Expected |
 |---|---|---|
-| 7c.1 | `curl http://localhost:8000/health` | Returns `{"status":"ok"}`. (Same `/health` endpoint covers both distributors.) |
-| 7c.2 | `curl 'http://localhost:8000/mouser/pricing?manufacturer_part_number=NE555P'` | HTTP 200 with JSON containing `manufacturer_part_number`, `mouser_part_number`, `currency`, non-empty `tiers` array (sorted ascending by `quantity`), and a `unit_price` / `tier_quantity` pair matching `tiers[-2]` (or `tiers[0]` if fewer than 2 entries). |
+| 7c.1 | `curl http://localhost:8001/health` | Returns `{"status":"ok"}`. (Same `/health` endpoint covers both distributors.) |
+| 7c.2 | `curl 'http://localhost:8001/mouser/pricing?manufacturer_part_number=NE555P'` | HTTP 200 with JSON containing `manufacturer_part_number`, `mouser_part_number`, `currency`, non-empty `tiers` array (sorted ascending by `quantity`), and a `unit_price` / `tier_quantity` pair matching `tiers[-2]` (or `tiers[0]` if fewer than 2 entries). |
 | 7c.3 | Serve `web/` locally (`cd web && python3 -m http.server 8080`), open `http://localhost:8080/mouser-search.html`, type a known MPN, submit. | Headline renders as `Qty <N> → $<P> USD / unit` with both numbers in the same large font weight/size. A muted line below shows `<MPN>  ·  Mouser: <Mouser-PN>`. No tier table appears. |
 | 7c.4 | Submit a bogus MPN like `NOTAPART_xyz`. | After "Loading…", an error message renders ("Part not found" surfaced as a 502 from the proxy), not the headline. |
-| 7c.5 | With one `uvicorn main:app --port 8000` from `api/server/`, open both `digikey-search.html` and `mouser-search.html` in two tabs simultaneously. Search a known MPN on each. | Each page hits its own path prefix (`/digikey/pricing` vs `/mouser/pricing`) on the same backend process. Both return their respective headlines. Network tab shows both responses coming from `localhost:8000`. |
+| 7c.5 | With one `uvicorn main:app --port 8001` from `api/server/`, open both `digikey-search.html` and `mouser-search.html` in two tabs simultaneously. Search a known MPN on each. | Each page hits its own path prefix (`/digikey/pricing` vs `/mouser/pricing`) on the same backend process. Both return their respective headlines. Network tab shows both responses coming from `localhost:8001`. |
 
 ### 7d. Defense-in-depth
 
@@ -186,7 +186,7 @@ Prerequisite: combined backend up per `api/server/README.md` with a real `MOUSER
 
 ## 8. Claude Code transcript viewer (issue #33)
 
-The `web/transcripts-viewer.html` page is a static frontend that calls the combined backend at `http://localhost:8000/claudecode/timeline` (`api/server/`). The backend reads JSONL files from `~/.claude/projects/**/*.jsonl` and returns a globally-sorted timeline of `(user_prompt, assistant_response)` pairs with per-day buckets. No external API, no credentials — purely local file read.
+The `web/transcripts-viewer.html` page is a static frontend that calls the combined backend at `http://localhost:8001/claudecode/timeline` (`api/server/`). The backend reads JSONL files from `~/.claude/projects/**/*.jsonl` and returns a globally-sorted timeline of `(user_prompt, assistant_response)` pairs with per-day buckets. No external API, no credentials — purely local file read.
 
 > **Refined in #35 — see § 9 below for the new layout cases.** 8a/8b still apply unchanged. 8c.7 (textarea-focus exemption) is obsolete since the textarea is gone in #35; the replacement regression case lives in § 9f.
 
@@ -201,7 +201,7 @@ The `web/transcripts-viewer.html` page is a static frontend that calls the combi
 
 | ID | Steps | Expected |
 |---|---|---|
-| 8b.1 | On the live `/transcripts-viewer.html` with no local backend running, wait for the initial load. | Response card shows: "Backend unreachable at `http://localhost:8000` — start the local server (see `api/server/README.md`)." No console crash. |
+| 8b.1 | On the live `/transcripts-viewer.html` with no local backend running, wait for the initial load. | Response card shows: "Backend unreachable at `http://localhost:8001` — start the local server (see `api/server/README.md`)." No console crash. |
 
 ### 8c. Local-backend smoke (developer-only)
 
@@ -209,8 +209,8 @@ Prerequisite: combined backend up per `api/server/README.md` (`.env` doesn't nee
 
 | ID | Steps | Expected |
 |---|---|---|
-| 8c.1 | `curl http://localhost:8000/health` | Returns `{"status":"ok"}`. |
-| 8c.2 | `curl -s 'http://localhost:8000/claudecode/timeline' \| jq '{prompts: (.prompts\|length), days: (.days\|length), first: .prompts[0]}'` | Returns JSON with non-empty `prompts` and `days` counts; the first prompt has `user_text`, `response_text`, `timestamp`, `session_id` strings. |
+| 8c.1 | `curl http://localhost:8001/health` | Returns `{"status":"ok"}`. |
+| 8c.2 | `curl -s 'http://localhost:8001/claudecode/timeline' \| jq '{prompts: (.prompts\|length), days: (.days\|length), first: .prompts[0]}'` | Returns JSON with non-empty `prompts` and `days` counts; the first prompt has `user_text`, `response_text`, `timestamp`, `session_id` strings. |
 | 8c.3 | Serve `web/` locally (`cd web && python3 -m http.server 8080`), open `http://localhost:8080/transcripts-viewer.html`. | Latest prompt's response renders in the top card; datetime label shows above the prompt editbox; the prompt textarea contains the user's prompt text. No "Prompt #N of M" line, no session-id chip, no sidebar, no session dropdown. |
 | 8c.4 | Press ↓ a few times. | The response card and prompt textarea update. The prompt index increments — may cross into a different session_id (verify by reading the timeline payload's `session_id` for the displayed prompt; it can change). |
 | 8c.5 | Press ←. | Jumps back to the previous day's first prompt. May cross session boundaries cleanly (the days array is global). |

--- a/web/digikey-search.html
+++ b/web/digikey-search.html
@@ -135,7 +135,7 @@
   <div id="result" aria-live="polite"></div>
 
   <script>
-    const BACKEND_URL = "http://localhost:8000";
+    const BACKEND_URL = "http://localhost:8001";
 
     const form = document.getElementById('search-form');
     const submitBtn = document.getElementById('submit-btn');

--- a/web/mouser-search.html
+++ b/web/mouser-search.html
@@ -125,7 +125,7 @@
   <div id="result" aria-live="polite"></div>
 
   <script>
-    const BACKEND_URL = "http://localhost:8000";
+    const BACKEND_URL = "http://localhost:8001";
 
     const form = document.getElementById('search-form');
     const submitBtn = document.getElementById('submit-btn');

--- a/web/transcripts-viewer.html
+++ b/web/transcripts-viewer.html
@@ -182,7 +182,7 @@
   </main>
 
   <script>
-    const BACKEND_URL = "http://localhost:8000";
+    const BACKEND_URL = "http://localhost:8001";
     const ALLOWED_LINK_SCHEME = /^(https?:|mailto:)/i;
     // Plan-file detection inside inline `code` spans: any absolute path under
     // `<home>/.claude/plans/<name>.md` becomes a clickable vscode://file/<path>


### PR DESCRIPTION
## Summary

Moves the local-development backend port from 8000 → 8001 because port 8000 sits inside Windows' WSL excluded-port range and isn't bindable on a WSL host. 8001 is adjacent (easy to remember) and doesn't collide with 8080 used by the static `python -m http.server`.

Updates the three web HTML pages' `BACKEND_URL` constants, the `api/server/README.md` (uvicorn command + listening URL doc + curl examples), and 13 occurrences in `web/TEST-PLAN.md` across §§ 6 / 7 / 8. No change to `api/server/main.py` — backend port is a uvicorn CLI flag, not a hardcoded constant; CORS `allow_origins` lists FRONTEND origins (5500 / 8080 / GH Pages) — none of which were 8000 anyway.

## Test plan

- [ ] `cd api/server && uvicorn main:app --port 8001` — server boots and listens on 8001.
- [ ] `curl http://localhost:8001/health` returns `{"status":"ok"}`.
- [ ] `cd web && python3 -m http.server 8080`, open `http://localhost:8080/transcripts-viewer.html` — page loads and calls `http://localhost:8001/claudecode/timeline` (DevTools Network tab confirms).
- [ ] Repeat for `digikey-search.html` and `mouser-search.html` — searches succeed against `http://localhost:8001/digikey/pricing` and `http://localhost:8001/mouser/pricing`.
- [ ] Trying to bind 8000 on WSL no longer matters — the new instructions skip it entirely.

Closes #58
