### PR TITLE
feat: load lands on first of last day (#66)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-03
 
+### feat: initial load opens first prompt of last day (issue #66 follow-up)
+
+- `web/transcripts-viewer.html`: changed the page-load default in the load IIFE so that when no `?prompt=` URL parameter is present, `startIndex = days[days.length - 1].first_prompt_index` (the **first prompt of the most-recent day**) instead of `Math.max(0, prompts.length - 1)` (most-recent prompt globally, which on a multi-prompt last day landed mid-day). This makes #66's "initialize prompt location of each day to be the first prompt of the day" apply at load time too, not only on the first ← / → visit to an unvisited day. Explicit URL override (`?prompt=N`) still wins. Empty-`days[]` payload falls through to the existing empty-state path (no crash).
+- The per-day position memory `lastIndexByDay` and the `targetForDay` indirection are **unchanged** — once you navigate around in-session, the memory is populated by `render` and used by ←/→ exactly as before. The only behavior change is which prompt is shown on the very first render.
+- `web/TEST-PLAN.md` § 13: updated preamble to call out the new load-default behavior alongside the existing in-session machinery. § 13a renamed to "Initialization — load default + unvisited-day fallback both land on first prompt of the day". § 13a.1 flipped from asserting the OLD `prompts.length - 1` landing to asserting the new `days[lastDay].first_prompt_index` landing. Added 13a.1-bis (explicit `?prompt=N` URL override still wins) and 13a.1-ter (empty-days fallback).
+
 ### docs: regression coverage for per-prompt cursor-position memory (issue #67)
 
 - `web/TEST-PLAN.md`: new § 14 (sub-sections 14a–14g, ~24 cases) locking in the existing `cursorByPromptIndex` behavior introduced in #45 and unchanged across #50 / #54 / #66. Covers each of #67's three requirements (initialize to `(1, 1)`, remember on visit, restore on transition), cursor-validity clamp safety against corrupted memory, interaction with intra-prompt motions (`h`/`j`/`k`/`l`/`G`/`<num>G`/`H`/`M`/`L`) vs prompt-swaps (↑/↓/←/→/search/cross-response), search auto-jump override behavior (§ 10n), and code-shape regression guards (greps for `cursorByPromptIndex` occurrence count, save-before-swap / restore-after-swap ordering invariant inside `render`).

--- a/web/TEST-PLAN.md
+++ b/web/TEST-PLAN.md
@@ -682,21 +682,23 @@ The issue also notes `gg (top of file) will be implemented with other "g" functi
 
 ## 13. Per-day prompt-position memory (issue #66)
 
-Issue #66 specifies three behaviors for `web/transcripts-viewer.html`'s day-navigation memory. All three are met by the existing `lastIndexByDay` / `targetForDay` machinery introduced in #35 and unchanged across #45 / #50 / #54 — this section is **regression coverage** for that pre-existing behavior, not a new feature. #66 was filed and accepted after #63 was rejected (which would have removed this behavior in favor of always-first-prompt-of-day landing).
+Issue #66 specifies three behaviors for `web/transcripts-viewer.html`'s day-navigation memory. The `lastIndexByDay` / `targetForDay` machinery (introduced #35, unchanged across #45 / #50 / #54) satisfies the **in-session** part of all three: per-day memory write on visit, fallback to `first_prompt_index` for unvisited days, transition reads via `targetForDay`. Per the #66 follow-up, the **initial-load default** was also changed so the viewer opens at `days[days.length - 1].first_prompt_index` (first prompt of the last day) instead of `prompts.length - 1` (most-recent prompt globally) — making the "initialize to first prompt of each day" requirement apply at load time too, not just on first ←/→ visit.
 
 | Requirement (#66) | How it's met in `main` |
 | --- | --- |
-| Initialize prompt location of each day to be the first prompt of the day | `targetForDay(day)` returns `day.first_prompt_index` whenever `lastIndexByDay[day.date]` is unset (or out of range). No explicit pre-population — the fallback path IS the initialization. |
+| Initialize prompt location of each day to be the first prompt of the day | (a) On initial load, `startIndex = days[days.length - 1].first_prompt_index` when no `?prompt=` URL param. (b) For every other day, `targetForDay(day)` returns `day.first_prompt_index` whenever `lastIndexByDay[day.date]` is unset (or out of range). |
 | If a day has been visited, remember the last visited prompt location of that day | `render(index)` writes `lastIndexByDay[p.day] = clamped` on every prompt-switch (line ~1051). "Visited" = "currently rendered". |
 | When transitioning to a day, jump to the saved prompt location of that day | `goToPrevDay` / `goToNextDay` call `render(targetForDay(days[di ± 1]))`. Arrow `←` / `→` are wired to those in the key handler. |
 
-Memory is **in-memory only** — a page refresh clears `lastIndexByDay`. This is intentional (mirrors `cursorByPromptIndex` from § 10m.3). If cross-refresh persistence is wanted later, it would need its own issue (localStorage backing) and isn't part of #66's scope.
+Memory is **in-memory only** — a page refresh clears `lastIndexByDay`. This is intentional (mirrors `cursorByPromptIndex` from § 10m.3). If cross-refresh persistence is wanted later, it would need its own issue (localStorage backing) and isn't part of #66's scope — see #68 in the backlog.
 
-### 13a. Initialization — unvisited days default to first prompt
+### 13a. Initialization — load default + unvisited-day fallback both land on first prompt of the day
 
 | ID | Steps | Expected |
 |---|---|---|
-| 13a.1 | Hard-refresh the page (no `?prompt=` URL parameter). Note the prompt index in the URL after load. | URL is rewritten to `?prompt=N` where `N === prompts.length - 1` (most-recent prompt globally — current load default; this case is asserting the load behavior is unchanged by #66, NOT first-prompt-of-last-day). |
+| 13a.1 | Hard-refresh the page (no `?prompt=` URL parameter). Note the prompt index in the URL after load and the `#prompt-line` timestamp. | URL is rewritten to `?prompt=N` where `N === days[days.length - 1].first_prompt_index` — the **first prompt of the last day**, not the most-recent prompt globally. Timestamp shown is the first prompt's `timestamp` of the last day. Verifiable against the `/claudecode/timeline` JSON payload's last `days[]` entry. |
+| 13a.1-bis | Load with `?prompt=5` in the URL. | Viewer renders prompt index 5 — the explicit URL override wins over the new load default. (§ 8c.8 / § 9f.4 regression unchanged.) |
+| 13a.1-ter | Backend returns an empty `days` array (zero prompts overall). | `lastDayFirst` evaluates to `0`; `render(0)` falls into the empty-state path inside `render` (no prompts to render) — viewer shows "No prompts found in `~/.claude/projects/`." muted message. No JS error. |
 | 13a.2 | After 13a.1, press ← (assuming there is a day before the last). | Viewer jumps to `days[lastDay - 1].first_prompt_index` — the previous day's **first** prompt, because that day has never been visited this session and `targetForDay` returns the `first_prompt_index` fallback. |
 | 13a.3 | Continue pressing ← repeatedly into older days. Each press lands on the first prompt of the destination day on the first visit. | Until a day has been visited, each ← landing is `days[di].first_prompt_index`. |
 

--- a/web/transcripts-viewer.html
+++ b/web/transcripts-viewer.html
@@ -1186,9 +1186,8 @@
         days = Array.isArray(data.days) ? data.days : [];
         const urlParams = new URLSearchParams(window.location.search);
         const requested = parseInt(urlParams.get('prompt') || '', 10);
-        const startIndex = Number.isFinite(requested)
-          ? requested
-          : Math.max(0, prompts.length - 1);
+        const lastDayFirst = days.length ? days[days.length - 1].first_prompt_index : 0;
+        const startIndex = Number.isFinite(requested) ? requested : lastDayFirst;
         render(startIndex);
       } catch (err) {
         const msg = err && err.message ? err.message : String(err);


### PR DESCRIPTION
## Summary

Follow-up to PR #69 (which only covered #66's in-session memory). Changes the initial load default in `web/transcripts-viewer.html` so that when no `?prompt=` URL parameter is present, the viewer opens at **the first prompt of the most-recent day** (`days[days.length - 1].first_prompt_index`) instead of the most-recent prompt globally.

The per-day in-session memory machinery (`lastIndexByDay`, `targetForDay`, the writes inside `render`, the reads inside `goToPrevDay` / `goToNextDay`) is **untouched** — once you ←/→ in-session, the saved per-day prompt position still wins exactly as before. This is the load-default piece of the rejected #63's diff, applied without the per-day-memory-removal piece that made #63 unacceptable.

Explicit `?prompt=N` URL override still wins. Empty `days[]` payload falls through to the existing empty-state path with no crash.

## Test plan

- [ ] Manual: hard refresh `transcripts-viewer.html` with no `?prompt=` query. URL is rewritten to `?prompt=N` where `N === days[days.length - 1].first_prompt_index`. `#prompt-line` shows the date of the last day and the timestamp of its first prompt (§ 13a.1).
- [ ] Manual: hard refresh with `?prompt=5` in the URL. Viewer renders prompt 5 (URL override still wins, § 13a.1-bis).
- [ ] Manual: navigate ↓↓↓ to land mid-day in day D. ← to day D-1, ↓↓ to a mid-day position, → back to day D. Cursor lands at the mid-day position you left, not at day D's first prompt (per-day memory still works, § 13b / § 13c unchanged).
- [ ] `grep -c lastIndexByDay web/transcripts-viewer.html` returns ≥ 4 (§ 13g.1 unchanged).
- [ ] `grep -c targetForDay web/transcripts-viewer.html` returns ≥ 4 (§ 13g.2 unchanged).

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
