### PR TITLE
feat: remove tool_call lines from viewer (#65)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-03
 
+### feat: remove tool_call lines from transcripts viewer (issue #65)
+
+- `api/server/claudecode_client.py`: assistant `tool_use` content blocks are now dropped at parse time, alongside the already-dropped `thinking` blocks. The `🔧 tool_call: Read... Bash... Edit...` lines that used to appear inside `response_text` between prose paragraphs are gone — the viewer surfaces only the user-facing prose Claude produced. The previous `_TOOL_CALL_PREFIX` constant, the `('text', …) | ('tool', …)` tuple shape returned by the old `_extract_assistant_items`, the `tool_buffer` / `flush_tools` grouping logic, and the leading-tool-call-line dropper are all removed — joining is now a plain `"\n\n".join(texts)` inside `_parse_session.flush`. Function renamed: `_extract_assistant_items` → `_extract_assistant_text_blocks` (now returns `list[str]`).
+- Frontend (`web/transcripts-viewer.html`) is unchanged — it renders whatever `response_text` it receives. An assistant turn that consisted only of tool calls (no text blocks) now produces `response_text = ""`, falling through to the existing `(no response captured)` placeholder.
+- `web/TEST-PLAN.md`: new § 15 (sub-sections 15a–15d, 14 cases) covering backend response-shape regression (`curl | jq | grep '🔧'` returns nothing), frontend rendering (prose-only / tool-only / mixed prompts), cursor / search / navigation invariants under the lower total-line count, and code-shape regression guards (greps for `🔧`, `_TOOL_CALL_PREFIX`, `'tool'` literal).
+
 ### feat: initial load opens first prompt of last day (issue #66 follow-up)
 
 - `web/transcripts-viewer.html`: changed the page-load default in the load IIFE so that when no `?prompt=` URL parameter is present, `startIndex = days[days.length - 1].first_prompt_index` (the **first prompt of the most-recent day**) instead of `Math.max(0, prompts.length - 1)` (most-recent prompt globally, which on a multi-prompt last day landed mid-day). This makes #66's "initialize prompt location of each day to be the first prompt of the day" apply at load time too, not only on the first ← / → visit to an unvisited day. Explicit URL override (`?prompt=N`) still wins. Empty-`days[]` payload falls through to the existing empty-state path (no crash).

--- a/api/server/claudecode_client.py
+++ b/api/server/claudecode_client.py
@@ -6,7 +6,7 @@ timeline that the /claudecode/* routes serve to the viewer page.
 
 JSONL event types observed in practice:
   - user                       — user prompt OR a tool_result echo (filter out the latter)
-  - assistant                  — Claude's reply, with content blocks (text/thinking/tool_use)
+  - assistant                  — Claude's reply, with content blocks (text/thinking/tool_use); only `text` blocks are surfaced
   - ai-title                   — auto-generated session title
   - queue-operation            — operational noise
   - attachment                 — attached file
@@ -86,80 +86,39 @@ def _extract_user_text(entry: dict[str, Any]) -> str | None:
     return text
 
 
-def _extract_assistant_items(entry: dict[str, Any]) -> list[tuple[str, str]]:
-    """Return typed items from an assistant entry as a list of (kind, value) pairs.
+def _extract_assistant_text_blocks(entry: dict[str, Any]) -> list[str]:
+    """Return only the text blocks from an assistant entry.
 
-    `kind` is either 'text' (value = the text) or 'tool' (value = the tool name).
-    `thinking` blocks are dropped. The list preserves the order of blocks in the entry
-    so a downstream pass can group consecutive `tool` items into one line.
+    `tool_use` and `thinking` blocks are dropped — the viewer surfaces just the
+    user-facing prose Claude produced, with no operational noise.
     """
     message = entry.get("message") or {}
     content = message.get("content")
     if isinstance(content, str):
-        return [("text", content)] if content else []
+        return [content] if content else []
     if not isinstance(content, list):
         return []
-    items: list[tuple[str, str]] = []
+    texts: list[str] = []
     for block in content:
         if not isinstance(block, dict):
             continue
-        btype = block.get("type")
-        if btype == "text" and isinstance(block.get("text"), str):
+        if block.get("type") == "text" and isinstance(block.get("text"), str):
             text = block["text"]
             if text:
-                items.append(("text", text))
-        elif btype == "tool_use":
-            name = block.get("name") or "tool"
-            items.append(("tool", name))
-        # 'thinking' blocks intentionally dropped
-    return items
-
-
-_TOOL_CALL_PREFIX = "🔧 tool_call:"
-
-
-def _render_response_items(items: list[tuple[str, str]]) -> str:
-    """Join a flat list of (kind, value) items into a renderable string.
-
-    Consecutive `tool` items collapse into one line:
-        🔧 tool_call: Read... Bash... Edit...
-    Non-consecutive (text-interleaved) tool items keep their own lines.
-
-    If the first chunk after grouping is a tool-call line, it is dropped — the viewer
-    leads with the assistant's first user-facing text instead of operational noise.
-    """
-    if not items:
-        return ""
-    chunks: list[str] = []
-    tool_buffer: list[str] = []
-
-    def flush_tools() -> None:
-        if tool_buffer:
-            chunks.append(_TOOL_CALL_PREFIX + " " + "... ".join(tool_buffer) + "...")
-            tool_buffer.clear()
-
-    for kind, value in items:
-        if kind == "tool":
-            tool_buffer.append(value)
-        else:
-            flush_tools()
-            chunks.append(value)
-    flush_tools()
-    if chunks and chunks[0].startswith(_TOOL_CALL_PREFIX):
-        chunks = chunks[1:]
-    return "\n\n".join(chunks)
+                texts.append(text)
+    return texts
 
 
 def _parse_session(path: Path) -> list[dict[str, Any]]:
     """Yield `(prompt, response)` pair dicts for one session file."""
     pairs: list[dict[str, Any]] = []
     current_prompt: dict[str, Any] | None = None
-    current_response_items: list[tuple[str, str]] = []
+    current_response_texts: list[str] = []
 
     def flush() -> None:
         if current_prompt is None:
             return
-        current_prompt["response_text"] = _render_response_items(current_response_items).strip()
+        current_prompt["response_text"] = "\n\n".join(current_response_texts).strip()
         pairs.append(current_prompt)
 
     try:
@@ -185,12 +144,12 @@ def _parse_session(path: Path) -> list[dict[str, Any]]:
                         "session_id": entry.get("sessionId") or path.stem,
                         "user_text": user_text,
                     }
-                    current_response_items = []
+                    current_response_texts = []
                 elif etype == "assistant":
                     if current_prompt is None:
                         # response with no preceding user prompt — skip
                         continue
-                    current_response_items.extend(_extract_assistant_items(entry))
+                    current_response_texts.extend(_extract_assistant_text_blocks(entry))
     except OSError:
         return []
     flush()

--- a/web/TEST-PLAN.md
+++ b/web/TEST-PLAN.md
@@ -835,6 +835,47 @@ Existing § 10m / § 10n / § 11d already cover much of this behavior end-to-end
 | 14g.2 | Read the `render(index)` function. | Contains both a save block (`if (prompts.length && currentIndex !== clamped) { cursorByPromptIndex[currentIndex] = …; }`) BEFORE the `currentIndex = clamped` assignment, AND a restore block (`const remembered = cursorByPromptIndex[clamped]; if (remembered) cursor = …; else cursor = { line: 1, col: 1 }; placeCursorAt(...)`) at the END. The ordering matters — saving after the swap would write to the wrong index. |
 | 14g.3 | Read the save block's guard. | `currentIndex !== clamped` — same-prompt renders (e.g. a no-op re-render) skip the save. Removing this guard would overwrite the saved cursor with the current cursor on every render, including intra-prompt motions if they ever started routing through `render`. |
 
+## 15. Tool-call lines removed from transcripts viewer (issue #65)
+
+Issue #65 removes the `🔧 tool_call: …` lines that used to appear inside `response_text` between prose paragraphs of assistant responses. The fix is **backend-only** in [api/server/claudecode_client.py](api/server/claudecode_client.py): `_extract_assistant_text_blocks(entry)` now collects only `text`-typed content blocks; `tool_use` blocks are dropped at parse time, alongside the already-dropped `thinking` blocks. The previous `_TOOL_CALL_PREFIX` constant, the `('text', …) | ('tool', …)` tuple shape, the `tool_buffer` / `flush_tools` grouping logic, and the leading-tool-call-line dropper are all gone — joining is now a plain `"\n\n".join(texts)` inside `_parse_session.flush`.
+
+The frontend (`web/transcripts-viewer.html`) is unchanged — the viewer just renders whatever `response_text` it receives. An assistant response that consists only of tool calls (no text blocks) now produces `response_text = ""`, which falls through to the frontend's existing `(no response captured)` placeholder.
+
+### 15a. Backend response shape — no tool_call prefix anywhere
+
+| ID | Steps | Expected |
+|---|---|---|
+| 15a.1 | `curl -s 'http://localhost:8001/claudecode/timeline' \| jq -r '.prompts[].response_text' \| grep -F '🔧 tool_call:'` | Zero matches across every prompt in the timeline. (Previously some prompts contained one or more `🔧 tool_call: Read... Bash... Edit...` lines mid-response.) |
+| 15a.2 | `curl -s 'http://localhost:8001/claudecode/timeline' \| jq -r '.prompts[].response_text' \| grep -F '🔧'` | Zero matches. The emoji was only used in the now-removed prefix; no other usage in real Claude transcripts. |
+| 15a.3 | Pick a prompt that used to show a `🔧 tool_call:` line mid-response (e.g. one in your local cache from before this change). Re-fetch its response_text. | Mid-response text now reads continuously across the spot where the tool-call line used to sit, separated by the same `\n\n` paragraph break that the join produces. No orphan blank lines. |
+
+### 15b. Frontend rendering
+
+| ID | Steps | Expected |
+|---|---|---|
+| 15b.1 | Open `transcripts-viewer.html`. Navigate to a prompt whose stored response had both prose paragraphs AND tool calls between them. | The rendered response shows the prose paragraphs back-to-back; no `🔧 tool_call: …` line appears. |
+| 15b.2 | Navigate to a prompt whose response was **only** tool calls (no text blocks at all — e.g. a "ran 3 tools then stopped" turn). | The viewer renders the existing `(no response captured)` placeholder text inside `#response-body`. No JS error, no blank card. |
+| 15b.3 | Navigate to a prompt with only text blocks (no tool calls). | Unchanged from before — the response renders identically to how it did with the old code (since the join already produced the same output for tool-free responses). |
+| 15b.4 | DevTools → search the page DOM for the string `🔧` or `tool_call:` after navigating across multiple prompts. | Zero hits in `#response-body` for any prompt. |
+
+### 15c. Cursor / search / navigation regressions
+
+| ID | Steps | Expected |
+|---|---|---|
+| 15c.1 | Visit a prompt that used to have N tool-call lines. Note that `totalLines()` for that response is now lower than it was before (the tool-call lines contributed `\n` separators that are gone). Press `G` to jump to the last line. | Cursor lands at the new last line (post-removal). No off-by-N error. |
+| 15c.2 | `/some-text<Enter>` for a string that previously appeared *after* a tool-call line in some prompt. | Search still finds it. Match position shifts upward by however many `\n` separators were removed, but the cursor lands on the correct character. |
+| 15c.3 | ←/→ day navigation, ↑/↓ prompt navigation, H/M/L screen motions. | All unchanged. |
+
+### 15d. Code-shape regression guards
+
+| ID | Steps | Expected |
+|---|---|---|
+| 15d.1 | `grep -nF '🔧' api/server/claudecode_client.py` | Zero matches. The emoji should not be re-introduced. |
+| 15d.2 | `grep -nF '_TOOL_CALL_PREFIX' api/server/claudecode_client.py` | Zero matches. The constant has been removed. |
+| 15d.3 | `grep -nF "'tool'" api/server/claudecode_client.py` | Zero matches for the `'tool'` kind tag (the tuple-shape sentinel). Docstrings may still mention `tool_use` to explain *what is dropped* — those don't use the bare `'tool'` literal. |
+| 15d.4 | Read `_extract_assistant_text_blocks`. | Returns `list[str]` of text-block contents only. No `tool_use` branch, no `('text', …)` tuple wrapping. |
+| 15d.5 | Read `_parse_session.flush`. | Inlines the join: `current_prompt["response_text"] = "\n\n".join(current_response_texts).strip()`. No call to a removed `_render_response_items` helper. |
+
 ## Exit criteria
 
 A change ships when:


### PR DESCRIPTION
## Summary

Removes the `🔧 tool_call: Read... Bash... Edit...` lines from the transcripts viewer. Fix is backend-only in [api/server/claudecode_client.py](api/server/claudecode_client.py): the assistant-message parser now collects only `text`-typed content blocks, dropping `tool_use` blocks at parse time alongside the already-dropped `thinking` blocks. The previous `_TOOL_CALL_PREFIX` constant, the `('text', …) | ('tool', …)` tuple shape, the `tool_buffer` / `flush_tools` grouping logic, and the leading-tool-call-line dropper are all removed — joining becomes a plain `"\n\n".join(texts)` inside `_parse_session.flush`. Function renamed: `_extract_assistant_items` → `_extract_assistant_text_blocks` (now returns `list[str]`).

Net: `claudecode_client.py` shrinks from ~124 to ~85 lines. Frontend (`web/transcripts-viewer.html`) is **unchanged** — tool-only assistant turns now produce `response_text = ""` and fall through to the existing `(no response captured)` placeholder.

## Test plan

- [ ] Backend smoke: `curl -s 'http://localhost:8001/claudecode/timeline' | jq -r '.prompts[].response_text' | grep -F '🔧' | wc -l` → 0 (§ 15a.1 / 15a.2).
- [ ] Frontend smoke: open viewer, navigate to a prompt that previously contained mid-response tool-call lines — the lines are gone (§ 15b.1).
- [ ] Frontend smoke: visit a tool-only assistant turn (if any in your timeline) — `(no response captured)` placeholder renders cleanly (§ 15b.2).
- [ ] Code-shape regressions all pass: `grep -F '🔧' api/server/claudecode_client.py`, `grep -F '_TOOL_CALL_PREFIX' …`, `grep -F "'tool'" …` all return 0 (§ 15d.1–15d.3).

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
