### PR TITLE
feat: switch news topics to Tech/Science (#90)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,15 @@
 
 ## 2026-06-07
 
+### feat: switch news topics to Technology and Science (issue #90)
+
+- Renamed the two category routes: `webapp/app/news/economy/` → `technology/` and `webapp/app/news/health/` → `science/` (via `git mv`).
+- `app/news/technology/page.tsx`: fetches gnews `category=technology`, heading "Technology News", helper `getTechnologyNews`, empty-state "No technology articles found." (was `category=business` / Economy).
+- `app/news/science/page.tsx`: fetches gnews `category=science`, heading "Science News", helper `getScienceNews`, empty-state "No science articles found." (was `category=health` / Health).
+- `app/news/page.tsx`: category nav now links `/news/technology` and `/news/science` with matching labels.
+- `webapp/CLAUDE.md`: route list updated to the new paths.
+- Verified: `npm run lint` + `npm run build` clean; `/news/technology` and `/news/science` return 200 with correct headings, old routes 404, `/news` nav points to the new routes.
+
 ### feat: migrate web to a Vercel-hosted Next.js app (`webapp/`, issue #88)
 
 - New top-level `webapp/` target: the `news-voice` Next.js 16 / React 19 / Tailwind 4 app copied in (source only, fresh history). Renamed package to `firstcontact-webapp`; set real `metadata` title/description; cleaned the merge-conflicted README; typed the news pages' article param (`app/news/types.ts`) so the target lints clean.

--- a/webapp/CLAUDE.md
+++ b/webapp/CLAUDE.md
@@ -9,7 +9,7 @@ issue #88). It serves three things:
 - **Homepage** (`app/page.tsx`) — the unified landing (hero / quote /
   changes-made-this-week / 30-day summary / tool links + a "Latest News" link).
   A client component; ported 1:1 from the former `web/index.html`.
-- **News reader** (`app/news/**`) — `/news`, `/news/health`, `/news/economy`.
+- **News reader** (`app/news/**`) — `/news`, `/news/technology`, `/news/science`.
   Headlines are fetched **server-side** from `gnews.io` using `GNEWS_API_KEY`
   (so this target needs a Node runtime — it can't be statically hosted).
   "Read Aloud" uses the browser `SpeechSynthesis` API (`app/news/TTSButton.tsx`).

--- a/webapp/app/news/page.tsx
+++ b/webapp/app/news/page.tsx
@@ -17,11 +17,11 @@ export default async function NewsPage() {
 
       {/* Category Navigation */}
       <nav style={{ marginBottom: 30, display: "flex", gap: 20 }}>
-        <Link href="/news/health" style={{ fontWeight: "bold" }}>
-          Health
+        <Link href="/news/technology" style={{ fontWeight: "bold" }}>
+          Technology
         </Link>
-        <Link href="/news/economy" style={{ fontWeight: "bold" }}>
-          Economy
+        <Link href="/news/science" style={{ fontWeight: "bold" }}>
+          Science
         </Link>
       </nav>
 

--- a/webapp/app/news/science/page.tsx
+++ b/webapp/app/news/science/page.tsx
@@ -1,23 +1,23 @@
 import TTSButton from "../TTSButton";
 import type { Article } from "../types";
 
-async function getHealthNews() {
+async function getScienceNews() {
   const apiKey = process.env.GNEWS_API_KEY;
 
   const res = await fetch(
-    `https://gnews.io/api/v4/top-headlines?category=health&lang=en&country=us&apikey=${apiKey}`,
+    `https://gnews.io/api/v4/top-headlines?category=science&lang=en&country=us&apikey=${apiKey}`,
     { cache: "no-store" }
   );
 
   return res.json();
 }
 
-export default async function HealthNewsPage() {
-  const data = await getHealthNews();
+export default async function ScienceNewsPage() {
+  const data = await getScienceNews();
 
   return (
     <div style={{ padding: 40, maxWidth: 800, margin: "0 auto" }}>
-      <h1 style={{ marginBottom: 20 }}>Health News</h1>
+      <h1 style={{ marginBottom: 20 }}>Science News</h1>
 
       {data.articles?.length > 0 ? (
         data.articles.map((article: Article, index: number) => (
@@ -57,7 +57,7 @@ export default async function HealthNewsPage() {
           </div>
         ))
       ) : (
-        <p>No health articles found.</p>
+        <p>No science articles found.</p>
       )}
     </div>
   );

--- a/webapp/app/news/technology/page.tsx
+++ b/webapp/app/news/technology/page.tsx
@@ -1,23 +1,23 @@
 import TTSButton from "../TTSButton";
 import type { Article } from "../types";
 
-async function getEconomyNews() {
+async function getTechnologyNews() {
   const apiKey = process.env.GNEWS_API_KEY;
 
   const res = await fetch(
-    `https://gnews.io/api/v4/top-headlines?category=business&lang=en&country=us&apikey=${apiKey}`,
+    `https://gnews.io/api/v4/top-headlines?category=technology&lang=en&country=us&apikey=${apiKey}`,
     { cache: "no-store" }
   );
 
   return res.json();
 }
 
-export default async function EconomyNewsPage() {
-  const data = await getEconomyNews();
+export default async function TechnologyNewsPage() {
+  const data = await getTechnologyNews();
 
   return (
     <div style={{ padding: 40, maxWidth: 800, margin: "0 auto" }}>
-      <h1 style={{ marginBottom: 20 }}>Economy News</h1>
+      <h1 style={{ marginBottom: 20 }}>Technology News</h1>
 
       {data.articles?.length > 0 ? (
         data.articles.map((article: Article, index: number) => (
@@ -57,7 +57,7 @@ export default async function EconomyNewsPage() {
           </div>
         ))
       ) : (
-        <p>No economy articles found.</p>
+        <p>No technology articles found.</p>
       )}
     </div>
   );


### PR DESCRIPTION
Swaps the news reader's two category sections from Economy/Health to Technology/Science. The `app/news/economy/` route becomes `app/news/technology/` (gnews `category=technology`, "Technology News") and `app/news/health/` becomes `app/news/science/` (`category=science`, "Science News"); the `/news` category nav and `webapp/CLAUDE.md` are updated to match. Pure category + label/route swap — no data plumbing changes.

Verified: lint + build clean, `/news/technology` and `/news/science` return 200 with correct headings, old routes 404, `/news` nav repointed. Vercel production redeploy to follow after merge.

Closes #90
