### PR TITLE
feat: Read Aloud on Latest News page (#92)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-07
 
+### feat: Read Aloud buttons on the Latest News page (issue #92)
+
+- `webapp/app/news/page.tsx`: imported `TTSButton` and rendered `<TTSButton text={`${article.title}. ${article.description}`} />` after each article's "Read more" link, matching the `/news/technology` and `/news/science` pages. The general `/news` feed previously had no TTS button.
+- Verified: `npm run lint` + `npm run build` clean; `/news` renders one Read Aloud button per article (10/10 with a live `GNEWS_API_KEY`).
+
 ### feat: switch news topics to Technology and Science (issue #90)
 
 - Renamed the two category routes: `webapp/app/news/economy/` → `technology/` and `webapp/app/news/health/` → `science/` (via `git mv`).

--- a/webapp/app/news/page.tsx
+++ b/webapp/app/news/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import TTSButton from "./TTSButton";
 import type { Article } from "./types";
 
 export default async function NewsPage() {
@@ -59,6 +60,8 @@ export default async function NewsPage() {
             >
               Read more →
             </a>
+
+            <TTSButton text={`${article.title}. ${article.description}`} />
           </div>
         ))
       ) : (


### PR DESCRIPTION
Adds the Read Aloud TTS button to each article on the general `/news` feed, matching the `/news/technology` and `/news/science` category pages — the main feed previously rendered only a "Read more" link. Single change in `app/news/page.tsx` (import `TTSButton` + render it per article).

Verified: lint + build clean; `/news` renders one Read Aloud button per article (10/10 with a live `GNEWS_API_KEY`).

Closes #92
