### PR TITLE
feat: TTS pause/resume + hold-restart (#94)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-07
 
+### feat: TTS button pause/resume + hold-to-restart (issue #94)
+
+- `webapp/app/news/TTSButton.tsx`: rewrote the single-action "Read Aloud" button into a play/pause/resume control with a hold-to-restart gesture. State machine: **idle** (`🔊 Read Aloud`, click → speak from start) → **playing** (`⏸️ Pause`, click → `speechSynthesis.pause()`) → **paused** (`🔊 Read Aloud`, click → `speechSynthesis.resume()`). A long-press (~500ms `HOLD_MS`) from any state restarts from the beginning (`cancel` + `speak`); the click that follows a hold is suppressed via `heldRef`.
+- Uses pointer events (`onPointerDown`/`Up`/`Leave`) for the hold timer; `userSelect: none` + `touchAction: manipulation` + `onContextMenu` preventDefault to keep long-press clean on touch. Detaches utterance handlers on restart/unmount so a `cancel()` can't `setState` on a stale/unmounted instance; starting one button cancels any other so only one reads at a time.
+- Verified: `npm run lint` + `npm run build` clean; `/news` renders 10 buttons at initial `Read Aloud` state. Click/hold/audio transitions require manual browser verification (SpeechSynthesis is unavailable headless).
+
 ### feat: Read Aloud buttons on the Latest News page (issue #92)
 
 - `webapp/app/news/page.tsx`: imported `TTSButton` and rendered `<TTSButton text={`${article.title}. ${article.description}`} />` after each article's "Read more" link, matching the `/news/technology` and `/news/science` pages. The general `/news` feed previously had no TTS button.

--- a/webapp/app/news/TTSButton.tsx
+++ b/webapp/app/news/TTSButton.tsx
@@ -1,16 +1,98 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type PlayState = "idle" | "playing" | "paused";
+
+// How long a press must be held (ms) before it counts as a "hold" (restart
+// from the beginning) rather than a tap (play / pause / resume).
+const HOLD_MS = 500;
+
 export default function TTSButton({ text }: { text: string }) {
-  const speak = () => {
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.rate = 1;
-    utterance.pitch = 1;
-    speechSynthesis.speak(utterance);
+  const [state, setState] = useState<PlayState>("idle");
+
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const holdTimer = useRef<number | null>(null);
+  // Set when a press crosses the hold threshold, so the click that fires on
+  // release is ignored (the hold already did its work).
+  const heldRef = useRef(false);
+
+  // Detach handlers from this button's current utterance so a later cancel()
+  // (ours or another button's) can't reset state we've since moved past.
+  const releaseUtterance = useCallback(() => {
+    if (utteranceRef.current) {
+      utteranceRef.current.onend = null;
+      utteranceRef.current.onerror = null;
+      utteranceRef.current = null;
+    }
+  }, []);
+
+  const speakFromStart = useCallback(() => {
+    releaseUtterance();
+    speechSynthesis.cancel(); // stop anything currently speaking (any button)
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1;
+    u.pitch = 1;
+    u.onend = () => setState("idle");
+    u.onerror = () => setState("idle");
+    utteranceRef.current = u;
+    speechSynthesis.speak(u);
+    setState("playing");
+  }, [text, releaseUtterance]);
+
+  // Clean up on unmount: drop the hold timer and detach handlers so a canceled
+  // utterance can't call setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (holdTimer.current) clearTimeout(holdTimer.current);
+      releaseUtterance();
+    };
+  }, [releaseUtterance]);
+
+  const handleClick = () => {
+    if (heldRef.current) {
+      // This click is the tail of a hold gesture — already handled.
+      heldRef.current = false;
+      return;
+    }
+    if (state === "playing") {
+      speechSynthesis.pause();
+      setState("paused");
+    } else if (state === "paused") {
+      speechSynthesis.resume();
+      setState("playing");
+    } else {
+      speakFromStart();
+    }
   };
+
+  const startHoldTimer = () => {
+    heldRef.current = false;
+    holdTimer.current = window.setTimeout(() => {
+      heldRef.current = true;
+      speakFromStart(); // hold => restart from the beginning
+    }, HOLD_MS);
+  };
+
+  const cancelHoldTimer = () => {
+    if (holdTimer.current) {
+      clearTimeout(holdTimer.current);
+      holdTimer.current = null;
+    }
+  };
+
+  const reading = state === "playing";
 
   return (
     <button
-      onClick={speak}
+      onPointerDown={startHoldTimer}
+      onPointerUp={cancelHoldTimer}
+      onPointerLeave={cancelHoldTimer}
+      onClick={handleClick}
+      onContextMenu={(e) => e.preventDefault()}
+      aria-label={
+        reading ? "Pause reading. Hold to restart from the beginning." : "Read aloud"
+      }
       style={{
         padding: "6px 12px",
         background: "#0070f3",
@@ -20,9 +102,12 @@ export default function TTSButton({ text }: { text: string }) {
         cursor: "pointer",
         marginTop: 10,
         fontSize: 14,
+        userSelect: "none",
+        WebkitUserSelect: "none",
+        touchAction: "manipulation",
       }}
     >
-      🔊 Read Aloud
+      {reading ? "⏸️ Pause" : "🔊 Read Aloud"}
     </button>
   );
 }


### PR DESCRIPTION
Rewrites the shared Read Aloud control (`app/news/TTSButton.tsx`) into a play/pause/resume button with a long-press hold-to-restart gesture, used by `/news`, `/news/technology`, and `/news/science`. Click toggles idle→play, playing→pause, paused→resume; the label shows "Pause" only while actively reading; a ~500ms hold from any state restarts from the beginning (and suppresses the trailing click). Starting one button cancels any other so only one article reads at a time.

Verified: lint + build clean; `/news` renders the button in its initial Read Aloud state. Interactive audio (play/pause/resume + hold-restart) needs a real browser — to be confirmed on the Vercel production deploy after merge.

Closes #94
