### PR TITLE
feat: drop redundant detail description (#98)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-09
 
+### feat: drop redundant description from iOS article detail (issue #98 follow-up)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: removed the standalone `description` block from `articleDetailScreen` — the full body scraped from the linked URL already contains it, so showing the GNews `description` above it was redundant. The detail screen now flows title → image → full body. Simplified `truncatedContent`'s fallback to always show the "No further text available" message when there's no `content` (the previous `article.description == nil` guard only mattered while the description was rendered).
+- Verified: `xcodebuild` (simulator) succeeds; simulator screenshot of the detail screen confirms the description is gone and title + image + full body render correctly (verified via a temporary launch-env hook, removed before commit).
+
 ### feat: iOS full-text article detail from linked URL (issue #98)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: the article detail screen (from #96) now fetches the **entire article body from the article's linked URL** instead of only GNews's ~160-char truncated `content`. New `ArticleTextState` (`loading`/`loaded`/`failed`) and `@State articleTextState`; a `.task(id: article.url)` on `articleDetailScreen` runs `loadFullText`, which fetches the page with a Safari-like `User-Agent` (15s timeout) and feeds the HTML to a pure-Swift readability heuristic.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -440,12 +440,6 @@ struct ContentView: View {
                         .clipped()
                         .clipShape(RoundedRectangle(cornerRadius: 10))
 
-                    if let description = article.description, !description.isEmpty {
-                        Text(description)
-                            .font(.system(size: 17, weight: .semibold))
-                            .opacity(0.95)
-                    }
-
                     articleBody(article)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -485,7 +479,7 @@ struct ContentView: View {
             Text(content)
                 .font(.system(size: 16))
                 .opacity(0.9)
-        } else if article.description == nil {
+        } else {
             Text("No further text available for this article.")
                 .font(.system(size: 15))
                 .opacity(0.7)


### PR DESCRIPTION
Follow-up refinement to the #98 article detail screen. The full body scraped from the linked URL already contains the lede/description, so the standalone GNews `description` block in `articleDetailScreen` was redundant — removed it. The detail screen now flows title → image → full body. Also simplified `truncatedContent`'s fallback to show the "No further text available" message whenever there's no `content` (the previous `article.description == nil` guard only mattered while the description was rendered).

Verified: `xcodebuild` (simulator) succeeds; simulator screenshot confirms the description is gone and title + image + full scrollable body render correctly.

Closes #98
