### PR TITLE
fix: iOS article detail margin overflows (#101)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-10
+
+### fix: pin iOS article detail column width (issue #101)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: fixed the article detail screen clipping its left margin and bleeding the image full-width on narrow devices (iPhone SE) for certain articles. Cause: a long unbreakable token in the extracted body (e.g. a bare URL) that the device's iOS won't wrap widened the leading-aligned content column past the screen, dragging the `.frame(maxWidth: .infinity)` image full-bleed with it. Wrapped the detail `ScrollView` in a `GeometryReader` and pinned the content column with `.frame(width: geo.size.width, alignment: .leading)` (padding applied inside the pin) so no body content can exceed the screen width; long tokens now wrap within the column. Added `.fixedSize(horizontal: false, vertical: true)` to the title and body text as belt-and-suspenders against horizontal expansion.
+- Also fixed the detail image bleeding into the right margin: a `scaledToFill` image with `.frame(maxWidth: .infinity)` applied directly to it overflowed its column on the trailing edge. Re-anchored the image on a `Color.clear` box (`.frame(maxWidth: .infinity).frame(height: 200)`) with the image as a clipped `.overlay`, so the box defines the exact column width and the image can't exceed it — the image now keeps equal 20pt margins on both sides.
+- Verified: `xcodebuild` (simulator) succeeds; reproduced and confirmed the fix on an iPhone SE (3rd gen) simulator with a synthetic long-token body — title, inset rounded image, and wrapped body all keep their 20pt side margins. (iOS 26.4 auto-breaks long tokens so the original overflow only shows on the older device OS; the width pin makes overflow impossible regardless of OS wrapping behavior.)
+
 ## 2026-06-09
 
 ### feat: drop redundant description from iOS article detail (issue #98 follow-up)

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -429,21 +429,34 @@ struct ContentView: View {
             }
             .padding(.horizontal, 12)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    Text(article.title)
-                        .font(.system(size: 26, weight: .bold))
+            // GeometryReader pins the content column to the screen width so a long
+            // unbreakable token in the body (e.g. a bare URL) can't widen the column
+            // past the screen — which previously clipped the left margin and pushed the
+            // image full-bleed on narrower devices. The hard `.frame(width:)` forces the
+            // body text to wrap within the column instead of overflowing it.
+            GeometryReader { geo in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text(article.title)
+                            .font(.system(size: 26, weight: .bold))
+                            .fixedSize(horizontal: false, vertical: true)
 
-                    articleImage(article)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 200)
-                        .clipped()
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        // Color.clear anchors the layout to exactly the column width; the
+                        // scaledToFill image rides in a clipped overlay so it can't overflow
+                        // the right margin the way `.frame(maxWidth: .infinity)` applied
+                        // directly to the overflowing image did.
+                        Color.clear
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 200)
+                            .overlay { articleImage(article) }
+                            .clipped()
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
 
-                    articleBody(article)
+                        articleBody(article)
+                    }
+                    .padding(20)
+                    .frame(width: geo.size.width, alignment: .leading)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(20)
             }
         }
         .foregroundStyle(.white)
@@ -459,6 +472,7 @@ struct ContentView: View {
             Text(text)
                 .font(.system(size: 16))
                 .opacity(0.9)
+                .fixedSize(horizontal: false, vertical: true)
         case .loading:
             truncatedContent(article)
             HStack(spacing: 8) {
@@ -479,6 +493,7 @@ struct ContentView: View {
             Text(content)
                 .font(.system(size: 16))
                 .opacity(0.9)
+                .fixedSize(horizontal: false, vertical: true)
         } else {
             Text("No further text available for this article.")
                 .font(.system(size: 15))


### PR DESCRIPTION
Fixes the article detail screen overflowing its margins on narrow devices (iPhone SE) for certain articles.

Two coupled defects: (1) a long unbreakable token in the extracted body (e.g. a bare URL) widened the leading-aligned content column past the screen, clipping the left margin and dragging the `.frame(maxWidth: .infinity)` image full-bleed; (2) the `scaledToFill` image bled past the right margin on its own.

Fix: pinned the detail content column to the screen width via a `GeometryReader` (`.frame(width: geo.size.width)`, padding inside) so no body content can exceed it, added `.fixedSize(horizontal: false, vertical: true)` to the text, and re-anchored the image on a `Color.clear` box with the image as a clipped overlay so it can't exceed the column. Image now keeps equal 20pt margins on both sides.

Verified on an iPhone SE (3rd gen) simulator with synthetic long-token and wide-image bodies — title, image, and wrapped body all hold their 20pt side margins.

Closes #101
