### PR TITLE
feat: landscape article pager + swipes (#105)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-10
 
+### feat: landscape layout + swipe mapping for iOS article pager (issue #105)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: added landscape-specific behavior to the swipe-pager article screen. New `@Environment(\.verticalSizeClass)` + `isLandscape` (compact height = landscape on iPhone). In landscape, `articleScreen` lays the image on the left half (`geo.size.width * 0.5`, full height) with the headline/description on the right half; portrait keeps the image across the top 35% with text below. Extracted the shared headline+description into an `articleText(_:)` helper.
+- Remapped pager navigation by orientation: landscape swipes on the horizontal axis (swipe-left = forward, mirroring portrait's swipe-up; swipe-right = back), portrait stays vertical. The page-transition slide also follows the axis (horizontal move in landscape) so a horizontal swipe doesn't animate vertically. The gesture is shared by the whole pager, so home screens navigate the same way in landscape.
+- Verified: `xcodebuild` (simulator) succeeds; confirmed the landscape layout on an iPhone SE (3rd gen) simulator (temporarily forced landscape-only to launch rotated) — image fills the left half, headline + description fill the right half.
+
 ### feat: shrink iOS article screen image to top 35% (issue #103)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: on the swipe-pager `articleScreen`, changed the headline image height from `geo.size.height / 2` (top 50%) to `geo.size.height * 0.35` (top 35%), giving the headline + description more room above the fold. Detail-screen image (fixed 200pt) unchanged.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-10
 
+### feat: shrink iOS article screen image to top 35% (issue #103)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: on the swipe-pager `articleScreen`, changed the headline image height from `geo.size.height / 2` (top 50%) to `geo.size.height * 0.35` (top 35%), giving the headline + description more room above the fold. Detail-screen image (fixed 200pt) unchanged.
+- Verified: `xcodebuild` (simulator) succeeds; iPhone SE (3rd gen) simulator screenshot confirms the image occupies the top ~35% with the headline/description filling the space below.
+
 ### fix: pin iOS article detail column width (issue #101)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: fixed the article detail screen clipping its left margin and bleeding the image full-width on narrow devices (iPhone SE) for certain articles. Cause: a long unbreakable token in the extracted body (e.g. a bare URL) that the device's iOS won't wrap widened the leading-aligned content column past the screen, dragging the `.frame(maxWidth: .infinity)` image full-bleed with it. Wrapped the detail `ScrollView` in a `GeometryReader` and pinned the content column with `.frame(width: geo.size.width, alignment: .leading)` (padding applied inside the pin) so no body content can exceed the screen width; long tokens now wrap within the column. Added `.fixedSize(horizontal: false, vertical: true)` to the title and body text as belt-and-suspenders against horizontal expansion.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -389,7 +389,7 @@ struct ContentView: View {
         GeometryReader { geo in
             VStack(spacing: 0) {
                 articleImage(article)
-                    .frame(width: geo.size.width, height: geo.size.height / 2)
+                    .frame(width: geo.size.width, height: geo.size.height * 0.35)
                     .clipped()
 
                 VStack(alignment: .leading, spacing: 12) {

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -91,6 +91,9 @@ struct ContentView: View {
     @State private var goingForward = true      // drives swipe transition direction
     @State private var detailArticle: Article?
     @State private var articleTextState: ArticleTextState = .loading
+    // On iPhone a compact vertical size class means landscape orientation.
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    private var isLandscape: Bool { verticalSizeClass == .compact }
 
     private static let summaryCacheKey = "firstcontact.summary30d.v1"
     private static let summaryTTLHours = 24
@@ -141,8 +144,12 @@ struct ContentView: View {
             .id(screenIndex)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .transition(.asymmetric(
-                insertion: .move(edge: goingForward ? .bottom : .top),
-                removal: .move(edge: goingForward ? .top : .bottom)
+                insertion: .move(edge: isLandscape
+                    ? (goingForward ? .trailing : .leading)
+                    : (goingForward ? .bottom : .top)),
+                removal: .move(edge: isLandscape
+                    ? (goingForward ? .leading : .trailing)
+                    : (goingForward ? .top : .bottom))
             ))
             .contentShape(Rectangle())
             .gesture(swipeGesture)
@@ -195,13 +202,22 @@ struct ContentView: View {
     private var swipeGesture: some Gesture {
         DragGesture(minimumDistance: 20)
             .onEnded { value in
-                let dy = value.translation.height
                 let dx = value.translation.width
-                guard abs(dy) > abs(dx), abs(dy) > 50 else { return }
+                let dy = value.translation.height
                 let total = totalScreens
                 guard total > 1 else { return }
+                // Landscape navigates on the horizontal axis (swipe-left = forward,
+                // mirroring portrait's swipe-up); portrait stays on the vertical axis.
+                let forward: Bool
+                if isLandscape {
+                    guard abs(dx) > abs(dy), abs(dx) > 50 else { return }
+                    forward = dx < 0
+                } else {
+                    guard abs(dy) > abs(dx), abs(dy) > 50 else { return }
+                    forward = dy < 0
+                }
                 withAnimation(.easeInOut(duration: 0.3)) {
-                    if dy < 0 {
+                    if forward {
                         goingForward = true
                         screenIndex = (screenIndex + 1) % total
                     } else {
@@ -387,31 +403,50 @@ struct ContentView: View {
 
     private func articleScreen(_ article: Article) -> some View {
         GeometryReader { geo in
-            VStack(spacing: 0) {
-                articleImage(article)
-                    .frame(width: geo.size.width, height: geo.size.height * 0.35)
-                    .clipped()
+            if isLandscape {
+                // Landscape: image fills the left half, text the right half.
+                HStack(spacing: 0) {
+                    articleImage(article)
+                        .frame(width: geo.size.width * 0.5, height: geo.size.height)
+                        .clipped()
 
-                VStack(alignment: .leading, spacing: 12) {
-                    Text(article.title)
-                        .font(.system(size: 24, weight: .bold))
-                        .multilineTextAlignment(.leading)
-                    if let description = article.description, !description.isEmpty {
-                        Text(description)
-                            .font(.system(size: 16))
-                            .opacity(0.9)
-                            .multilineTextAlignment(.leading)
-                    }
-                    Spacer(minLength: 0)
+                    articleText(article)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        .padding(20)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                .padding(20)
+            } else {
+                // Portrait: image across the top 35%, text below.
+                VStack(spacing: 0) {
+                    articleImage(article)
+                        .frame(width: geo.size.width, height: geo.size.height * 0.35)
+                        .clipped()
+
+                    articleText(article)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        .padding(20)
+                }
             }
         }
         .ignoresSafeArea(edges: .top)
         .foregroundStyle(.white)
         .contentShape(Rectangle())
         .onTapGesture { withAnimation { detailArticle = article } }
+    }
+
+    // Headline + description block shared by the portrait and landscape article layouts.
+    private func articleText(_ article: Article) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(article.title)
+                .font(.system(size: 24, weight: .bold))
+                .multilineTextAlignment(.leading)
+            if let description = article.description, !description.isEmpty {
+                Text(description)
+                    .font(.system(size: 16))
+                    .opacity(0.9)
+                    .multilineTextAlignment(.leading)
+            }
+            Spacer(minLength: 0)
+        }
     }
 
     private func articleDetailScreen(_ article: Article) -> some View {


### PR DESCRIPTION
Adds landscape-specific behavior to the swipe-pager article screen.

- **Layout:** in landscape, the image fills the left half (50% width, full height) with the headline + description on the right half; portrait is unchanged (image top 35%, text below).
- **Swipe mapping:** landscape navigates on the horizontal axis — swipe-left = forward (mirroring portrait's swipe-up), swipe-right = back; portrait stays vertical. The page-transition slide follows the same axis. Detection via `@Environment(\.verticalSizeClass)` (compact height = landscape on iPhone). The gesture is pager-wide, so home screens navigate horizontally in landscape too.

Verified: `xcodebuild` (simulator) succeeds; landscape layout confirmed on an iPhone SE (3rd gen) simulator — image left half, headline + description right half. Swipe-direction mapping and transition axis verified by code review (gestures can't be exercised via screenshot).

Closes #105
