### PR TITLE
feat: remove swipe-pager animation (#107)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-10
 
+### feat: remove swipe-pager transition animation (issue #107)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: removed the slide animation on the swipe pager so the article screen's image/title/description no longer animate when paging — content swaps instantly (no slide or fade). Dropped the `.transition(.asymmetric(.move…))` on `currentScreen` and the `withAnimation(.easeInOut)` wrapper around the `screenIndex` change in `swipeGesture`, and removed the now-dead `goingForward` state. Applies to the whole pager (home screens swap instantly too). Swipe navigation (next/prev, wrap-around, portrait + landscape axes) is unchanged; the tap-to-open detail-screen slide is unaffected.
+- Verified: `xcodebuild` (simulator) succeeds; iPhone SE (3rd gen) screenshot confirms the article screen still renders correctly (animation absence verified by code review — not capturable in a still).
+
 ### feat: landscape layout + swipe mapping for iOS article pager (issue #105)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: added landscape-specific behavior to the swipe-pager article screen. New `@Environment(\.verticalSizeClass)` + `isLandscape` (compact height = landscape on iPhone). In landscape, `articleScreen` lays the image on the left half (`geo.size.width * 0.5`, full height) with the headline/description on the right half; portrait keeps the image across the top 35% with text below. Extracted the shared headline+description into an `articleText(_:)` helper.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -88,7 +88,6 @@ struct ContentView: View {
     @State private var summary30dView = 0
     @State private var newsState: NewsState = .loading
     @State private var screenIndex = 0          // 0 = home; i>=1 = news article i-1
-    @State private var goingForward = true      // drives swipe transition direction
     @State private var detailArticle: Article?
     @State private var articleTextState: ArticleTextState = .loading
     // On iPhone a compact vertical size class means landscape orientation.
@@ -143,14 +142,6 @@ struct ContentView: View {
         currentScreen
             .id(screenIndex)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .transition(.asymmetric(
-                insertion: .move(edge: isLandscape
-                    ? (goingForward ? .trailing : .leading)
-                    : (goingForward ? .bottom : .top)),
-                removal: .move(edge: isLandscape
-                    ? (goingForward ? .leading : .trailing)
-                    : (goingForward ? .top : .bottom))
-            ))
             .contentShape(Rectangle())
             .gesture(swipeGesture)
     }
@@ -216,14 +207,11 @@ struct ContentView: View {
                     guard abs(dy) > abs(dx), abs(dy) > 50 else { return }
                     forward = dy < 0
                 }
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    if forward {
-                        goingForward = true
-                        screenIndex = (screenIndex + 1) % total
-                    } else {
-                        goingForward = false
-                        screenIndex = (screenIndex - 1 + total) % total
-                    }
+                // No animation: pages swap instantly (no slide or fade).
+                if forward {
+                    screenIndex = (screenIndex + 1) % total
+                } else {
+                    screenIndex = (screenIndex - 1 + total) % total
                 }
             }
     }


### PR DESCRIPTION
Removes the slide animation on the swipe pager so the article screen's image, title, and description no longer animate when paging — content swaps instantly (no slide or fade).

Dropped the `.transition(.asymmetric(.move…))` on the pager's `currentScreen` and the `withAnimation(.easeInOut)` wrapper around the `screenIndex` change in `swipeGesture`, and removed the now-dead `goingForward` state. The transition was a single shared modifier, so this applies to the whole pager (home screens swap instantly too). Swipe navigation (next/prev, wrap-around, portrait + landscape axes) and the separate tap-to-open detail-screen slide are unchanged.

Verified: `xcodebuild` (simulator) succeeds; iPhone SE (3rd gen) screenshot confirms the article screen still renders correctly. Animation absence isn't capturable in a still, so the no-slide/no-fade behavior was verified by code review.

Closes #107
