### PR TITLE
feat: swipe to dismiss detail screen (#109)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-10
 
+### feat: swipe to dismiss full-text detail screen (issue #109)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: added a horizontal swipe (left or right) on `articleDetailScreen` that dismisses back to the pager — same as the back chevron (`withAnimation { detailArticle = nil }`). Implemented as a `.simultaneousGesture(DragGesture(minimumDistance: 20))` that only acts on horizontal-dominant swipes (`abs(width) > abs(height)` and `> 50pt`), so the body's vertical scrolling is unaffected.
+- Verified: `xcodebuild` (simulator) succeeds; iPhone SE (3rd gen) screenshot confirms the detail screen still renders/scrolls (the swipe-dismiss gesture verified by code review — not capturable in a still).
+
 ### feat: remove swipe-pager transition animation (issue #107)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: removed the slide animation on the swipe pager so the article screen's image/title/description no longer animate when paging — content swaps instantly (no slide or fade). Dropped the `.transition(.asymmetric(.move…))` on `currentScreen` and the `withAnimation(.easeInOut)` wrapper around the `screenIndex` change in `swipeGesture`, and removed the now-dead `goingForward` state. Applies to the whole pager (home screens swap instantly too). Swipe navigation (next/prev, wrap-around, portrait + landscape axes) is unchanged; the tap-to-open detail-screen slide is unaffected.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -483,6 +483,18 @@ struct ContentView: View {
             }
         }
         .foregroundStyle(.white)
+        // A horizontal swipe (either direction) dismisses, like the back chevron.
+        // simultaneousGesture so the body's vertical scrolling still works; we only
+        // act on horizontal-dominant swipes.
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 20)
+                .onEnded { value in
+                    if abs(value.translation.width) > abs(value.translation.height),
+                       abs(value.translation.width) > 50 {
+                        withAnimation { detailArticle = nil }
+                    }
+                }
+        )
         .task(id: article.url) { await loadFullText(article) }
     }
 


### PR DESCRIPTION
On the full-text article detail screen, a horizontal swipe (left or right) now dismisses back to the article pager — the same action and animation as the back chevron (`withAnimation { detailArticle = nil }`).

Implemented as a `.simultaneousGesture(DragGesture(minimumDistance: 20))` that only acts on horizontal-dominant swipes (`abs(width) > abs(height)` and `> 50pt`), so the body's vertical scrolling is unaffected.

Verified: `xcodebuild` (simulator) succeeds; iPhone SE (3rd gen) screenshot confirms the detail screen still renders. The swipe-dismiss gesture and scroll coexistence aren't capturable in a still, so they were verified by code review.

Closes #109
