### PR TITLE
feat: swipe to show Gemini key term (#111)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-10
 
+### feat: cross-axis swipe shows Gemini key term for article (issue #111)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: a swipe on the axis opposite to navigation (horizontal in portrait, vertical in landscape) on an article now opens a new `keywordScreen` showing a Gemini-extracted key word/term for that article, centered, with a top-left exit arrow. New `KeywordState` (`loading`/`loaded`/`failed`/`missingKey`), `keywordArticle`/`keywordState` state, and a `currentArticle` helper.
+- Refactored `swipeGesture` to route by axis: a swipe whose dominant axis matches the nav axis (`horizontal == isLandscape`) navigates as before; the cross-axis swipe (>50pt) opens the key-term screen for the current article (no-op on home/status). `loadKeyword`/`generateKeyword` call Gemini (`gemini-2.5-flash-lite`, temp 0.2) with a dedicated `keywordSystemPrompt` using only the headline + description; the back chevron mirrors the detail screen's dismiss.
+- Verified: `xcodebuild` (simulator) succeeds; the keyword prompt was validated against the Gemini API (e.g. "background apps", "Whale graveyard", "Knicks vs. Spurs"); an iPhone SE (3rd gen) screenshot shows the real Gemini term ("background apps") centered with the exit arrow. The cross-axis gesture itself was verified by code review (gestures aren't capturable in a still).
+
 ### feat: swipe to dismiss full-text detail screen (issue #109)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: added a horizontal swipe (left or right) on `articleDetailScreen` that dismisses back to the pager — same as the back chevron (`withAnimation { detailArticle = nil }`). Implemented as a `.simultaneousGesture(DragGesture(minimumDistance: 20))` that only acts on horizontal-dominant swipes (`abs(width) > abs(height)` and `> 50pt`), so the body's vertical scrolling is unaffected.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -77,6 +77,14 @@ enum ArticleTextState {
     case failed
 }
 
+// Gemini-extracted key word/term for an article (from headline + description only).
+enum KeywordState {
+    case loading
+    case loaded(String)
+    case failed
+    case missingKey
+}
+
 struct ContentView: View {
     @State private var quote: Quote?
     @State private var quoteError = false
@@ -90,6 +98,8 @@ struct ContentView: View {
     @State private var screenIndex = 0          // 0 = home; i>=1 = news article i-1
     @State private var detailArticle: Article?
     @State private var articleTextState: ArticleTextState = .loading
+    @State private var keywordArticle: Article?
+    @State private var keywordState: KeywordState = .loading
     // On iPhone a compact vertical size class means landscape orientation.
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     private var isLandscape: Bool { verticalSizeClass == .compact }
@@ -110,6 +120,11 @@ struct ContentView: View {
         No bullet points, no emojis, no markdown, no headings. \
         Plain prose only. Do not include preamble like 'Here is the summary:'.
         """
+    private static let keywordSystemPrompt = """
+        You extract the single most important key word or short term (1-4 words) from a \
+        news headline and description. Respond with ONLY that word or term — no punctuation \
+        wrapping, no quotes, no explanation, no preamble. Use only the provided headline and description.
+        """
 
     var body: some View {
         ZStack {
@@ -125,6 +140,9 @@ struct ContentView: View {
 
             if let article = detailArticle {
                 articleDetailScreen(article)
+                    .transition(.move(edge: .trailing))
+            } else if let article = keywordArticle {
+                keywordScreen(article)
                     .transition(.move(edge: .trailing))
             } else {
                 pager
@@ -190,28 +208,37 @@ struct ContentView: View {
         return newsCount + 1
     }
 
+    // The article currently shown by the pager, or nil on the home/status screens.
+    private var currentArticle: Article? {
+        guard screenIndex >= 1, case .ready(let articles) = newsState,
+              screenIndex - 1 < articles.count else { return nil }
+        return articles[screenIndex - 1]
+    }
+
     private var swipeGesture: some Gesture {
         DragGesture(minimumDistance: 20)
             .onEnded { value in
                 let dx = value.translation.width
                 let dy = value.translation.height
-                let total = totalScreens
-                guard total > 1 else { return }
-                // Landscape navigates on the horizontal axis (swipe-left = forward,
-                // mirroring portrait's swipe-up); portrait stays on the vertical axis.
-                let forward: Bool
-                if isLandscape {
-                    guard abs(dx) > abs(dy), abs(dx) > 50 else { return }
-                    forward = dx < 0
+                let horizontal = abs(dx) > abs(dy)
+                // Navigation runs on the horizontal axis in landscape, vertical in portrait.
+                if horizontal == isLandscape {
+                    let primary = isLandscape ? dx : dy
+                    guard abs(primary) > 50 else { return }
+                    let total = totalScreens
+                    guard total > 1 else { return }
+                    // No animation: pages swap instantly (no slide or fade).
+                    if primary < 0 {
+                        screenIndex = (screenIndex + 1) % total
+                    } else {
+                        screenIndex = (screenIndex - 1 + total) % total
+                    }
                 } else {
-                    guard abs(dy) > abs(dx), abs(dy) > 50 else { return }
-                    forward = dy < 0
-                }
-                // No animation: pages swap instantly (no slide or fade).
-                if forward {
-                    screenIndex = (screenIndex + 1) % total
-                } else {
-                    screenIndex = (screenIndex - 1 + total) % total
+                    // Cross-axis swipe (horizontal in portrait, vertical in landscape) on an
+                    // article opens its Gemini key-term screen; a no-op elsewhere.
+                    let cross = isLandscape ? dy : dx
+                    guard abs(cross) > 50, let article = currentArticle else { return }
+                    withAnimation { keywordArticle = article }
                 }
             }
     }
@@ -496,6 +523,59 @@ struct ContentView: View {
                 }
         )
         .task(id: article.url) { await loadFullText(article) }
+    }
+
+    // Reached by a cross-axis swipe on an article: shows a Gemini-extracted key term
+    // (from the headline + description) centered, with a top-left exit arrow.
+    private func keywordScreen(_ article: Article) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button {
+                    withAnimation { keywordArticle = nil }
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 20, weight: .bold))
+                        .padding(8)
+                }
+                .accessibilityLabel("Back to article")
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+
+            Spacer()
+            keywordContent
+                .padding(.horizontal, 24)
+            Spacer()
+        }
+        .foregroundStyle(.white)
+        .task(id: article.title) { await loadKeyword(article) }
+    }
+
+    @ViewBuilder
+    private var keywordContent: some View {
+        switch keywordState {
+        case .loading:
+            VStack(spacing: 12) {
+                ProgressView().tint(.white)
+                Text("Finding the key term\u{2026}")
+                    .font(.system(size: 15))
+                    .opacity(0.7)
+            }
+        case .loaded(let term):
+            Text(term)
+                .font(.system(size: 40, weight: .bold))
+                .multilineTextAlignment(.center)
+        case .failed:
+            Text("Couldn't extract a key term.")
+                .font(.system(size: 16))
+                .opacity(0.8)
+                .multilineTextAlignment(.center)
+        case .missingKey:
+            Text("Set GEMINI_API_KEY in Secrets.xcconfig — see ios/CLAUDE.md.")
+                .font(.system(size: 15))
+                .opacity(0.85)
+                .multilineTextAlignment(.center)
+        }
     }
 
     // The article body: the full text scraped from article.url once it loads, with the
@@ -921,6 +1001,36 @@ struct ContentView: View {
             throw URLError(.cannotParseResponse)
         }
         return text
+    }
+
+    // MARK: - Key term (Gemini, from headline + description)
+
+    private func loadKeyword(_ article: Article) async {
+        keywordState = .loading
+        guard let apiKey = geminiAPIKey() else {
+            keywordState = .missingKey
+            return
+        }
+        let description = article.description ?? ""
+        let input = "Headline: \(article.title)\nDescription: \(description)"
+        do {
+            let term = try await generateKeyword(apiKey: apiKey, input: input)
+            keywordState = term.isEmpty ? .failed : .loaded(term)
+        } catch {
+            keywordState = .failed
+        }
+    }
+
+    private func generateKeyword(apiKey: String, input: String) async throws -> String {
+        let config = GenerationConfig(temperature: 0.2)
+        let model = GenerativeModel(
+            name: Self.geminiModel,
+            apiKey: apiKey,
+            generationConfig: config,
+            systemInstruction: ModelContent(parts: [.text(Self.keywordSystemPrompt)])
+        )
+        let response = try await model.generateContent(input)
+        return (response.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func wordCount(_ text: String) -> Int {


### PR DESCRIPTION
A cross-axis swipe on an article (horizontal in portrait, vertical in landscape — the opposite of the navigation axis) opens a new key-term screen: a Gemini-extracted word/term derived from **only** the article's headline + description, displayed centered, with a top-left exit arrow.

`swipeGesture` now routes by axis — nav-axis swipes page as before, cross-axis swipes (>50pt) open the key-term screen for the current article (no-op on home/status). `loadKeyword`/`generateKeyword` call `gemini-2.5-flash-lite` (temp 0.2) with a dedicated keyword prompt; the back chevron mirrors the detail screen's dismiss.

Verified: `xcodebuild` (simulator) succeeds; prompt validated against the Gemini API ("background apps", "Whale graveyard", "Knicks vs. Spurs"); iPhone SE (3rd gen) screenshot shows the live Gemini term ("background apps") centered with the exit arrow. The cross-axis gesture was verified by code review (not capturable in a still).

Closes #111
