### PR TITLE
feat: rework long-press gestures (#115)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-06-13
+
+### feat: rework long-press gestures (issue #115)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: the long-press that opens the compose screen now fires only on the welcome (home) screen — moved the `.simultaneousGesture(LongPressGesture)` off the pager/overlay group and onto `homeScreen` (with `.contentShape(Rectangle())` so the whole area is pressable).
+- The Gemini key-term screen now opens on a **long-press of an article** instead of a cross-axis swipe: added a `.simultaneousGesture(LongPressGesture)` to `articleScreen` that sets `keywordArticle`, dropped the cross-axis branch (and the now-unused `currentArticle` helper) from `swipeGesture`. Pager navigation swipes and tap-to-open-detail are unchanged.
+
 ## 2026-06-11
 
 ### feat: long-press opens iMessage-style compose screen (issue #113)

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -153,26 +153,14 @@ struct ContentView: View {
             if showCompose {
                 composeScreen
                     .transition(.move(edge: .trailing))
+            } else if let article = detailArticle {
+                articleDetailScreen(article)
+                    .transition(.move(edge: .trailing))
+            } else if let article = keywordArticle {
+                keywordScreen(article)
+                    .transition(.move(edge: .trailing))
             } else {
-                Group {
-                    if let article = detailArticle {
-                        articleDetailScreen(article)
-                            .transition(.move(edge: .trailing))
-                    } else if let article = keywordArticle {
-                        keywordScreen(article)
-                            .transition(.move(edge: .trailing))
-                    } else {
-                        pager
-                    }
-                }
-                // Long-press on any non-compose screen opens the compose screen.
-                // simultaneousGesture coexists with the pager's drag and the panels'
-                // button taps; attaching it only here keeps the compose screen's own
-                // text-field long-press (native text selection) intact.
-                .simultaneousGesture(
-                    LongPressGesture(minimumDuration: 0.5)
-                        .onEnded { _ in withAnimation { showCompose = true } }
-                )
+                pager
             }
         }
         .task { await loadQuote() }
@@ -226,6 +214,14 @@ struct ContentView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
                 .padding()
         }
+        // Long-press on the welcome screen opens the compose screen. simultaneousGesture
+        // coexists with the panels' button taps (tap-to-cycle still works); scoping it to
+        // homeScreen means other pager screens and the article/key-term overlays don't trigger it.
+        .contentShape(Rectangle())
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in withAnimation { showCompose = true } }
+        )
     }
 
     // Total swipe screens = home + one per article (or a single status screen
@@ -236,13 +232,6 @@ struct ContentView: View {
         return newsCount + 1
     }
 
-    // The article currently shown by the pager, or nil on the home/status screens.
-    private var currentArticle: Article? {
-        guard screenIndex >= 1, case .ready(let articles) = newsState,
-              screenIndex - 1 < articles.count else { return nil }
-        return articles[screenIndex - 1]
-    }
-
     private var swipeGesture: some Gesture {
         DragGesture(minimumDistance: 20)
             .onEnded { value in
@@ -250,23 +239,18 @@ struct ContentView: View {
                 let dy = value.translation.height
                 let horizontal = abs(dx) > abs(dy)
                 // Navigation runs on the horizontal axis in landscape, vertical in portrait.
-                if horizontal == isLandscape {
-                    let primary = isLandscape ? dx : dy
-                    guard abs(primary) > 50 else { return }
-                    let total = totalScreens
-                    guard total > 1 else { return }
-                    // No animation: pages swap instantly (no slide or fade).
-                    if primary < 0 {
-                        screenIndex = (screenIndex + 1) % total
-                    } else {
-                        screenIndex = (screenIndex - 1 + total) % total
-                    }
+                // A cross-axis swipe is ignored — the Gemini key-term screen now opens on a
+                // long-press of the article (see articleScreen).
+                guard horizontal == isLandscape else { return }
+                let primary = isLandscape ? dx : dy
+                guard abs(primary) > 50 else { return }
+                let total = totalScreens
+                guard total > 1 else { return }
+                // No animation: pages swap instantly (no slide or fade).
+                if primary < 0 {
+                    screenIndex = (screenIndex + 1) % total
                 } else {
-                    // Cross-axis swipe (horizontal in portrait, vertical in landscape) on an
-                    // article opens its Gemini key-term screen; a no-op elsewhere.
-                    let cross = isLandscape ? dy : dx
-                    guard abs(cross) > 50, let article = currentArticle else { return }
-                    withAnimation { keywordArticle = article }
+                    screenIndex = (screenIndex - 1 + total) % total
                 }
             }
     }
@@ -474,6 +458,12 @@ struct ContentView: View {
         .foregroundStyle(.white)
         .contentShape(Rectangle())
         .onTapGesture { withAnimation { detailArticle = article } }
+        // Long-press an article (any non-home screen) opens its Gemini key-term screen.
+        // simultaneousGesture so it coexists with the tap-to-open-detail and the pager swipe.
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in withAnimation { keywordArticle = article } }
+        )
     }
 
     // Headline + description block shared by the portrait and landscape article layouts.
@@ -553,7 +543,7 @@ struct ContentView: View {
         .task(id: article.url) { await loadFullText(article) }
     }
 
-    // Reached by a cross-axis swipe on an article: shows a Gemini-extracted key term
+    // Reached by a long-press on an article: shows a Gemini-extracted key term
     // (from the headline + description) centered, with a top-left exit arrow.
     private func keywordScreen(_ article: Article) -> some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
Reworks the iOS long-press gesture model: the compose-screen long-press now fires only on the welcome (home) screen, and the Gemini key-term screen opens on a long-press of an article instead of a cross-axis swipe. The cross-axis branch was removed from `swipeGesture` (now navigation-only) along with the unused `currentArticle` helper. Pager navigation swipes and tap-to-open-detail are unchanged.

All changes are in `ios/FirstContact/FirstContact/ContentView.swift` plus a `ChangeLog.md` entry. Verified: `xcodebuild` (simulator) succeeds with no errors/unused-symbol warnings; iPhone 17 sim screenshot confirms the welcome screen renders unchanged. Article/key-term layouts are untouched (gesture rewiring only), behavior verified by code review.

Closes #115
