### PR TITLE
feat: delete compose messages (#117)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+### feat: delete saved compose messages via long-press (issue #117)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: long-pressing a message bubble in the compose screen now shows a native context menu with a destructive **Delete** action. Added a `.contextMenu` on the bubble and a `delete(_:)` helper that removes the message by `id` and re-persists via the existing `saveComposeMessages()`. Per-message only — no clear-all, no confirmation dialog, no layout change.
+
 ### feat: rework long-press gestures (issue #115)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: the long-press that opens the compose screen now fires only on the welcome (home) screen — moved the `.simultaneousGesture(LongPressGesture)` off the pager/overlay group and onto `homeScreen` (with `.contentShape(Rectangle())` so the whole area is pressable).

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -627,6 +627,13 @@ struct ContentView: View {
                                     .padding(.horizontal, 14)
                                     .padding(.vertical, 8)
                                     .background(Color.blue, in: RoundedRectangle(cornerRadius: 18))
+                                    .contextMenu {
+                                        Button(role: .destructive) {
+                                            withAnimation { delete(message) }
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                    }
                             }
                             .id(message.id)
                         }
@@ -670,6 +677,11 @@ struct ContentView: View {
         guard !text.isEmpty else { return }
         messages.append(ComposeMessage(id: UUID(), text: text))
         draft = ""
+        saveComposeMessages()
+    }
+
+    private func delete(_ message: ComposeMessage) {
+        messages.removeAll { $0.id == message.id }
         saveComposeMessages()
     }
 


### PR DESCRIPTION
Adds per-message deletion to the long-press compose screen: long-pressing a message bubble reveals a native context menu with a destructive **Delete** action that removes that single message and re-persists the thread to `UserDefaults`. Per-message only — no clear-all, no confirmation dialog, no layout change.

Implemented in `ios/FirstContact/FirstContact/ContentView.swift` via a `.contextMenu` on each bubble plus a `delete(_:)` helper reusing the existing `saveComposeMessages()`. Verified: `xcodebuild` (simulator) succeeds; iPhone 17 sim screenshot (seeded bubbles, then reverted) confirms the thread renders unchanged with the menu wired in; deployed to the connected physical iPhone for real-hardware testing. The long-press context-menu interaction is verified on device / by code review.

Closes #117
