### PR TITLE
feat: compose-style keyword panel (#123)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-13
 
+### feat: compose-style key-term panel with its own keyword list (issue #123)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: turned the key-term half-sheet into a compose UI — a scrollable thread of saved keyword bubbles above an input box pre-filled with the Gemini term, with long-press-to-delete per bubble. New `Keyword` model, `keywords`/`keywordDraft`/`keywordFieldFocused` state, `firstcontact.keywords.v1` cache key, and `sendKeyword`/`deleteKeyword`/`loadKeywords`/`saveKeywords` helpers (mirroring the compose-message ones). `loadKeyword` now sets `keywordDraft` to the term on success.
+- The keyword list is its own persisted store, separate from the home compose messages; the panel placeholder reads "Keyword". Replaced the Close bar with the input bar (dismiss still via drag or tapping the dimmed peek) and shrank `keywordContent` to a compact loading/error status line. Half-sheet shell, `ComposeMessage`, and the home compose screen are unchanged.
+
 ### feat: half-size key-term sheet over the article (issue #121)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: reworked the Gemini key-term screen from a full-screen overlay into a half-size sheet that peeks over the (dimmed) article. Portrait occupies the bottom half and slides up from the bottom; landscape occupies the right half and slides in from the right (`.containerRelativeFrame`, `UnevenRoundedRectangle` rounding only the inner corners). The pager renders behind as a frozen peek (`.allowsHitTesting` off) with a `Color.black.opacity(0.35)` scrim.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: turned the key-term half-sheet into a compose UI — a scrollable thread of saved keyword bubbles above an input box pre-filled with the Gemini term, with long-press-to-delete per bubble. New `Keyword` model, `keywords`/`keywordDraft`/`keywordFieldFocused` state, `firstcontact.keywords.v1` cache key, and `sendKeyword`/`deleteKeyword`/`loadKeywords`/`saveKeywords` helpers (mirroring the compose-message ones). `loadKeyword` now sets `keywordDraft` to the term on success.
 - The keyword list is its own persisted store, separate from the home compose messages; the panel placeholder reads "Keyword". Replaced the Close bar with the input bar (dismiss still via drag or tapping the dimmed peek) and shrank `keywordContent` to a compact loading/error status line. Half-sheet shell, `ComposeMessage`, and the home compose screen are unchanged.
+- The keyword thread is a static (non-scrolling) stack — no `ScrollView` — so the panel-wide drag-to-dismiss has nothing to conflict with. (Trade-off: a long thread can overflow the half-panel.)
+- Keyword bubbles now lay out as wrapping chips via a new `FlowLayout` (`Layout` protocol): left-to-right, wrapping top-to-bottom from the top-left corner, instead of one right-aligned bubble per row.
 
 ### feat: half-size key-term sheet over the article (issue #121)
 

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -49,6 +49,13 @@ struct ComposeMessage: Codable, Identifiable {
     let text: String
 }
 
+// A saved keyword from the key-term panel — its own persisted list, separate from the
+// compose messages above. Same shape; kept distinct so the two threads don't mix.
+struct Keyword: Codable, Identifiable {
+    let id: UUID
+    let text: String
+}
+
 // MARK: - News (gnews.io)
 
 struct Article: Codable, Identifiable {
@@ -108,6 +115,9 @@ struct ContentView: View {
     @State private var keywordArticle: Article?
     @State private var keywordState: KeywordState = .loading
     @State private var keywordDragOffset: CGFloat = 0
+    @State private var keywords: [Keyword] = []
+    @State private var keywordDraft = ""
+    @FocusState private var keywordFieldFocused: Bool
     @State private var showCompose = false
     @State private var messages: [ComposeMessage] = []
     @State private var draft = ""
@@ -118,6 +128,7 @@ struct ContentView: View {
 
     private static let summaryCacheKey = "firstcontact.summary30d.v1"
     private static let composeCacheKey = "firstcontact.compose.v1"
+    private static let keywordCacheKey = "firstcontact.keywords.v1"
     private static let summaryTTLHours = 24
     private static let geminiModel = "gemini-2.5-flash-lite"
     private static let issueWindowDays = 30
@@ -178,6 +189,7 @@ struct ContentView: View {
         .task { await loadSummary() }
         .task { await loadNews() }
         .task { messages = loadComposeMessages() }
+        .task { keywords = loadKeywords() }
     }
 
     // Vertical swipe pager: home at index 0, news articles after it, wrapping in a
@@ -553,10 +565,12 @@ struct ContentView: View {
         .task(id: article.url) { await loadFullText(article) }
     }
 
-    // Reached by a long-press on an article: a half-size sheet showing a Gemini-extracted
-    // key term, peeking over the (dimmed) article. Portrait = bottom half (slides up);
-    // landscape = right half (slides in). Dismiss by dragging it down/right, tapping the
-    // dimmed area outside, or the Close bar. A grabber handle hints the drag.
+    // Reached by a long-press on an article: a half-size compose sheet for keywords,
+    // peeking over the (dimmed) article. A thread of saved keyword bubbles (own store,
+    // separate from the compose messages) sits above an input box pre-filled with the
+    // Gemini-extracted term. Portrait = bottom half (slides up); landscape = right half
+    // (slides in). Dismiss by dragging it down/right or tapping the dimmed area outside.
+    // A grabber handle hints the drag; long-press a bubble to delete it.
     private func keywordPanel(_ article: Article) -> some View {
         // Round only the inner corners so the outer edges sit flush to the screen.
         let shape = UnevenRoundedRectangle(
@@ -567,25 +581,63 @@ struct ContentView: View {
             style: .continuous
         )
         return VStack(spacing: 0) {
-            Spacer(minLength: 0)
-            keywordContent
-                .padding(.horizontal, 24)
-            Spacer(minLength: 0)
-
-            Button {
-                withAnimation { keywordArticle = nil }
-            } label: {
-                Text("Close")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .background(.white.opacity(0.15))
-                    .overlay(
-                        Rectangle().fill(.white.opacity(0.2)).frame(height: 1),
-                        alignment: .top
-                    )
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(spacing: 8) {
+                        ForEach(keywords) { keyword in
+                            HStack {
+                                Spacer(minLength: 40)
+                                Text(keyword.text)
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 8)
+                                    .background(Color.blue, in: RoundedRectangle(cornerRadius: 18))
+                                    .contextMenu {
+                                        Button(role: .destructive) {
+                                            withAnimation { deleteKeyword(keyword) }
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                    }
+                            }
+                            .id(keyword.id)
+                        }
+                    }
+                    .padding()
+                    .padding(.top, isLandscape ? 0 : 12)
+                    .padding(.leading, isLandscape ? 12 : 0)
+                }
+                .onChange(of: keywords.count) {
+                    guard let last = keywords.last else { return }
+                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                }
             }
-            .accessibilityLabel("Close")
+
+            keywordContent
+
+            HStack(spacing: 8) {
+                TextField("Keyword", text: $keywordDraft)
+                    .textFieldStyle(.plain)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .overlay(Capsule().stroke(.white.opacity(0.25), lineWidth: 1))
+                    .focused($keywordFieldFocused)
+                    .submitLabel(.send)
+                    .onSubmit(sendKeyword)
+
+                if !keywordDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button(action: sendKeyword) {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 30))
+                            .foregroundStyle(.white)
+                    }
+                    .accessibilityLabel("Send keyword")
+                }
+            }
+            .padding()
         }
         .foregroundStyle(.white)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -618,30 +670,34 @@ struct ContentView: View {
             }
     }
 
+    // Compact status shown just above the keyword input: a spinner while the Gemini term
+    // loads, an error / missing-key hint otherwise. Empty once loaded — the term is then
+    // pre-filled into the input box (keywordDraft).
     @ViewBuilder
     private var keywordContent: some View {
         switch keywordState {
         case .loading:
-            VStack(spacing: 12) {
+            HStack(spacing: 8) {
                 ProgressView().tint(.white)
                 Text("Finding the key term\u{2026}")
-                    .font(.system(size: 15))
+                    .font(.system(size: 13))
                     .opacity(0.7)
             }
-        case .loaded(let term):
-            Text(term)
-                .font(.system(size: 40, weight: .bold))
-                .multilineTextAlignment(.center)
+            .padding(.bottom, 4)
         case .failed:
             Text("Couldn't extract a key term.")
-                .font(.system(size: 16))
+                .font(.system(size: 13))
                 .opacity(0.8)
-                .multilineTextAlignment(.center)
+                .padding(.bottom, 4)
         case .missingKey:
             Text("Set GEMINI_API_KEY in Secrets.xcconfig — see ios/CLAUDE.md.")
-                .font(.system(size: 15))
+                .font(.system(size: 12))
                 .opacity(0.85)
                 .multilineTextAlignment(.center)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 4)
+        case .loaded:
+            EmptyView()
         }
     }
 
@@ -742,6 +798,31 @@ struct ContentView: View {
     private func saveComposeMessages() {
         guard let data = try? JSONEncoder().encode(messages) else { return }
         UserDefaults.standard.set(data, forKey: Self.composeCacheKey)
+    }
+
+    // MARK: - Keyword thread (key-term panel; own store, separate from compose messages)
+
+    private func sendKeyword() {
+        let text = keywordDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        keywords.append(Keyword(id: UUID(), text: text))
+        keywordDraft = ""
+        saveKeywords()
+    }
+
+    private func deleteKeyword(_ keyword: Keyword) {
+        keywords.removeAll { $0.id == keyword.id }
+        saveKeywords()
+    }
+
+    private func loadKeywords() -> [Keyword] {
+        guard let data = UserDefaults.standard.data(forKey: Self.keywordCacheKey) else { return [] }
+        return (try? JSONDecoder().decode([Keyword].self, from: data)) ?? []
+    }
+
+    private func saveKeywords() {
+        guard let data = try? JSONEncoder().encode(keywords) else { return }
+        UserDefaults.standard.set(data, forKey: Self.keywordCacheKey)
     }
 
     // The article body: the full text scraped from article.url once it loads, with the
@@ -1181,7 +1262,12 @@ struct ContentView: View {
         let input = "Headline: \(article.title)\nDescription: \(description)"
         do {
             let term = try await generateKeyword(apiKey: apiKey, input: input)
-            keywordState = term.isEmpty ? .failed : .loaded(term)
+            if term.isEmpty {
+                keywordState = .failed
+            } else {
+                keywordState = .loaded(term)
+                keywordDraft = term   // pre-fill the input so the term is ready to edit/send
+            }
         } catch {
             keywordState = .failed
         }

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -56,6 +56,52 @@ struct Keyword: Codable, Identifiable {
     let text: String
 }
 
+// Wrapping flow layout: places subviews left-to-right, wrapping to the next line when the
+// available width runs out, top-to-bottom, starting at the top-left. Used for keyword chips.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if rowWidth > 0, rowWidth + spacing + size.width > maxWidth {
+                totalWidth = max(totalWidth, rowWidth)
+                totalHeight += rowHeight + spacing
+                rowWidth = size.width
+                rowHeight = size.height
+            } else {
+                rowWidth += (rowWidth > 0 ? spacing : 0) + size.width
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+        totalWidth = max(totalWidth, rowWidth)
+        totalHeight += rowHeight
+        return CGSize(width: min(totalWidth, maxWidth), height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
 // MARK: - News (gnews.io)
 
 struct Article: Codable, Identifiable {
@@ -580,39 +626,29 @@ struct ContentView: View {
             topTrailingRadius: isLandscape ? 0 : 20,
             style: .continuous
         )
+        // Compose content: a static (non-scrolling) keyword thread + status + input.
+        // No ScrollView, so the panel-wide drag-to-dismiss has nothing to conflict with.
         return VStack(spacing: 0) {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    VStack(spacing: 8) {
-                        ForEach(keywords) { keyword in
-                            HStack {
-                                Spacer(minLength: 40)
-                                Text(keyword.text)
-                                    .font(.system(size: 16))
-                                    .foregroundStyle(.white)
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 8)
-                                    .background(Color.blue, in: RoundedRectangle(cornerRadius: 18))
-                                    .contextMenu {
-                                        Button(role: .destructive) {
-                                            withAnimation { deleteKeyword(keyword) }
-                                        } label: {
-                                            Label("Delete", systemImage: "trash")
-                                        }
-                                    }
+            // Bubbles flow left-to-right and wrap top-to-bottom, starting at the top-left.
+            FlowLayout(spacing: 8) {
+                ForEach(keywords) { keyword in
+                    Text(keyword.text)
+                        .font(.system(size: 16))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Color.blue, in: RoundedRectangle(cornerRadius: 18))
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                withAnimation { deleteKeyword(keyword) }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
                             }
-                            .id(keyword.id)
                         }
-                    }
-                    .padding()
-                    .padding(.top, isLandscape ? 0 : 12)
-                    .padding(.leading, isLandscape ? 12 : 0)
-                }
-                .onChange(of: keywords.count) {
-                    guard let last = keywords.last else { return }
-                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
                 }
             }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
             keywordContent
 


### PR DESCRIPTION
Turns the Gemini key-term half-sheet into a compose-style screen for keywords: a scrollable thread of saved keyword bubbles above an input box pre-filled with the extracted term, with long-press-to-delete per bubble. It is backed by its own persisted list (new `Keyword` model, `firstcontact.keywords.v1`), separate from the home compose messages.

The panel placeholder/labels read "Keyword"; `ComposeMessage` and the home compose screen are untouched. The Close bar is replaced by the input bar (dismiss still via drag or tapping the dimmed peek); the half-sheet shell is unchanged. All in `ios/FirstContact/FirstContact/ContentView.swift`.

Verified: `xcodebuild` (simulator) succeeds; portrait + landscape screenshots confirm the layout; deployed to the connected physical iPhone for on-device gesture testing.

Closes #123
