### PR TITLE
feat: exclude/include keyword bubbles (#125)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-13
 
+### feat: exclude/include a keyword (red bubble) from long-press menu (issue #125)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: added an **Exclude**/**Include** toggle above **Delete** in a keyword bubble's long-press context menu. A normal (blue) bubble shows "Exclude" (turns it red); a red bubble shows "Include" (turns it back blue). Backed by the keyword's new `excluded` flag (`keyword.excluded ? Color.red : Color.blue`) and a `toggleExcluded(_:)` helper that flips the flag and persists via `saveKeywords()`. `Keyword` gained a `var excluded: Bool = false` with a custom `init(from:)` (`decodeIfPresent`) so keywords saved before the field existed still load.
+- Bubbles render via a `sortedKeywords` computed view that lists non-excluded (blue) first and excluded (red) last (stable within each group), so a newly added keyword slots in among the blues and toggling exclude/include moves a bubble between the groups. Storage order is unchanged.
+
 ### feat: compose-style key-term panel with its own keyword list (issue #123)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: turned the key-term half-sheet into a compose UI — a scrollable thread of saved keyword bubbles above an input box pre-filled with the Gemini term, with long-press-to-delete per bubble. New `Keyword` model, `keywords`/`keywordDraft`/`keywordFieldFocused` state, `firstcontact.keywords.v1` cache key, and `sendKeyword`/`deleteKeyword`/`loadKeywords`/`saveKeywords` helpers (mirroring the compose-message ones). `loadKeyword` now sets `keywordDraft` to the term on success.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -50,10 +50,27 @@ struct ComposeMessage: Codable, Identifiable {
 }
 
 // A saved keyword from the key-term panel — its own persisted list, separate from the
-// compose messages above. Same shape; kept distinct so the two threads don't mix.
+// compose messages above. `excluded` keywords render as a red bubble.
 struct Keyword: Codable, Identifiable {
     let id: UUID
     let text: String
+    var excluded: Bool = false
+
+    enum CodingKeys: String, CodingKey { case id, text, excluded }
+
+    init(id: UUID, text: String, excluded: Bool = false) {
+        self.id = id
+        self.text = text
+        self.excluded = excluded
+    }
+
+    // Decode `excluded` defensively so keywords saved before the field existed still load.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        text = try c.decode(String.self, forKey: .text)
+        excluded = try c.decodeIfPresent(Bool.self, forKey: .excluded) ?? false
+    }
 }
 
 // Wrapping flow layout: places subviews left-to-right, wrapping to the next line when the
@@ -631,14 +648,24 @@ struct ContentView: View {
         return VStack(spacing: 0) {
             // Bubbles flow left-to-right and wrap top-to-bottom, starting at the top-left.
             FlowLayout(spacing: 8) {
-                ForEach(keywords) { keyword in
+                ForEach(sortedKeywords) { keyword in
                     Text(keyword.text)
                         .font(.system(size: 16))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 8)
-                        .background(Color.blue, in: RoundedRectangle(cornerRadius: 18))
+                        .background(keyword.excluded ? Color.red : Color.blue,
+                                    in: RoundedRectangle(cornerRadius: 18))
                         .contextMenu {
+                            Button {
+                                withAnimation { toggleExcluded(keyword) }
+                            } label: {
+                                if keyword.excluded {
+                                    Label("Include", systemImage: "plus.circle")
+                                } else {
+                                    Label("Exclude", systemImage: "minus.circle")
+                                }
+                            }
                             Button(role: .destructive) {
                                 withAnimation { deleteKeyword(keyword) }
                             } label: {
@@ -849,6 +876,18 @@ struct ContentView: View {
     private func deleteKeyword(_ keyword: Keyword) {
         keywords.removeAll { $0.id == keyword.id }
         saveKeywords()
+    }
+
+    private func toggleExcluded(_ keyword: Keyword) {
+        guard let i = keywords.firstIndex(where: { $0.id == keyword.id }) else { return }
+        keywords[i].excluded.toggle()
+        saveKeywords()
+    }
+
+    // Display order: non-excluded (blue) bubbles first, excluded (red) last. Stable within
+    // each group (insertion order preserved). Storage order is unchanged — this is display-only.
+    private var sortedKeywords: [Keyword] {
+        keywords.filter { !$0.excluded } + keywords.filter { $0.excluded }
     }
 
     private func loadKeywords() -> [Keyword] {


### PR DESCRIPTION
Adds an Exclude/Include toggle above Delete in a keyword bubble's long-press context menu: a blue (normal) bubble shows **Exclude** (turns it red), a red bubble shows **Include** (turns it back blue). Backed by a new persisted `excluded` flag on `Keyword` and a `toggleExcluded(_:)` helper. `Keyword` decodes `excluded` defensively (`decodeIfPresent`) so keywords saved before the field existed still load.

Bubbles render via a `sortedKeywords` computed view — non-excluded (blue) first, excluded (red) last, stable within each group — so a newly added keyword slots in among the blues and toggling moves a bubble between the groups. Storage order is unchanged. All in `ios/FirstContact/FirstContact/ContentView.swift`.

Verified: `xcodebuild` succeeds; simulator screenshots confirm red excluded vs blue normal bubbles and the blue-first/red-last ordering from an interleaved stored list; deployed to the physical iPhone for on-device menu testing.

Closes #125
