### PR TITLE
docs: document device-deploy convention (#119)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-14
 
+### docs: document iOS device-deploy verification convention (issue #119)
+
+- `ios/CLAUDE.md`: expanded the brief script mention into a "Deploying to a physical device" subsection under "Verifying UI changes" — documents deploying debug builds to the connected iPhone for real-hardware testing (the simulator can't drive gestures), the one-command `scripts/deploy-device.sh`, the equivalent manual `xcodebuild -sdk iphoneos` build + `devicectl install`/`launch` steps with generic auto-detection (no hardcoded UDID), and the gotchas (check device connected, ~7-day free-signing expiry, benign `Code=1002` noise, locked-device `Code=10002` launch refusal).
+
 ### feat: one-command device-deploy helper script (issue #118)
 
 - `ios/FirstContact/scripts/deploy-device.sh`: new helper that builds the app for the connected iPhone (Debug, `-sdk iphoneos`, generic destination) and installs + launches it via `devicectl` in one command. Auto-detects the connected device's identifier from `xcrun devicectl list devices` (no hardcoded name/UDID) and fails with a clear message if none is connected; resolves the built `.app` and bundle id from `xcodebuild -showBuildSettings`; launch failure (e.g. locked device) warns rather than erroring since the install already succeeded.

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -84,10 +84,49 @@ issues the simulator misses (true `backdrop-filter` rendering, scroll inertia,
 real network conditions). But it's the cheapest, most reliable check for the
 whole class of bugs that compile fine yet render wrong.
 
-To deploy a Debug build to the connected iPhone in one command, run
-[`scripts/deploy-device.sh`](FirstContact/scripts/deploy-device.sh): it
-auto-detects the connected device, builds for iphoneos, and installs +
-launches via `devicectl` (no hardcoded UDID).
+### Deploying to a physical device
+
+The simulator can't drive gestures (long-press, swipe, context menus) or real
+rendering/network conditions, so iOS changes should **also be deployed to the
+physical iPhone connected to the Mac** for real-hardware testing. The target is
+**auto-detected** from `xcrun devicectl list devices` — never hardcode a device
+name or UDID, so this works regardless of which device is attached.
+
+One command does it:
+
+```bash
+ios/FirstContact/scripts/deploy-device.sh
+```
+
+It auto-detects the connected device, builds for iphoneos, and installs +
+launches via `devicectl`. The equivalent manual steps:
+
+```bash
+cd ios/FirstContact
+# 1. Connected device's devicectl identifier (the UUID on a row in the "connected" state)
+DEVICE=$(xcrun devicectl list devices \
+  | awk 'tolower($0) ~ /connected/ {
+      for (i=1;i<=NF;i++) if ($i ~ /^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$/) { print $i; exit }
+    }')
+# 2. Build for the device (generic destination + automatic provisioning — no device id needed)
+xcodebuild -scheme FirstContact -sdk iphoneos -configuration Debug \
+  -destination 'generic/platform=iOS' -allowProvisioningUpdates build
+# 3. Resolve the built .app, then install + launch
+APP=$(xcodebuild -showBuildSettings -scheme FirstContact -configuration Debug -sdk iphoneos \
+  | awk '/ BUILT_PRODUCTS_DIR / {print $3; exit}')/FirstContact.app
+xcrun devicectl device install app --device "$DEVICE" "$APP"
+xcrun devicectl device process launch --device "$DEVICE" com.vwong.FirstContact
+```
+
+Notes:
+
+- Check a device is connected first — `xcrun devicectl list devices` should show
+  it as `connected` (the script fails with a clear message if none is).
+- Free-signing provisioning expires ~7 days; just rebuild/redeploy when stale.
+- `devicectl` prints a benign `Error … Code=1002 "No provider was found."` line
+  to stderr — install/launch still succeed; ignore it.
+- A **locked** device can refuse the launch (`Code=10002`) even though the
+  install succeeded — unlock and rerun, or open the app from the home screen.
 
 ### Surfacing screenshots in issue comments
 


### PR DESCRIPTION
Documents the "deploy debug builds to the connected physical device during verification" workflow as a project convention in `ios/CLAUDE.md` — a new "Deploying to a physical device" subsection under "Verifying UI changes".

Covers why (the simulator can't drive gestures or real rendering/network), the one-command `scripts/deploy-device.sh` (#118), the equivalent manual `xcodebuild -sdk iphoneos` build + `xcrun devicectl device install app`/`process launch` steps with generic auto-detection (no hardcoded device name or UDID), and the gotchas: check a device is connected first, ~7-day free-signing expiry, the benign `Code=1002 "No provider was found."` line, and a locked device refusing launch (`Code=10002`).

Docs-only; the referenced script path resolves on `main`.

Closes #119
