### PR TITLE
feat: cache key-term panel Gemini result (#133)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-14
 
+### feat: cache key-term panel's Gemini result per article (issue #133)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: the long-press key-term panel (`loadKeyword`) now caches its Gemini-extracted term per `article.url` in a new `keywordTermCache` session dictionary, mirroring the drill-down's `spawnCache`. Reopening the panel for the same headline reuses the cached term (instant pre-fill, no spinner) instead of re-running Gemini; the term is stored on first successful extraction. Session-memory only — no persistence across launches.
+
 ### feat: include article content in news search (issue #131)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: GNews keyword search now matches article content, not just title/description. Both the home category feed (`fetchNews`, `top-headlines`) and the related-news drill-down (`searchNews`, `/search`) send `in=title,description,content`. Added `max=10` to the `top-headlines` request (the free-tier ceiling) to match the search request.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -185,6 +185,7 @@ struct ContentView: View {
     @State private var screenIndex = 0          // 0 = home; i>=1 = news article i-1
     @State private var spawnedFeed: NewsFeed?                 // nil = base pager; one level only
     @State private var spawnCache: [String: NewsState] = [:] // related-news by source article.url (session memory)
+    @State private var keywordTermCache: [String: String] = [:] // key-term panel's Gemini term by article.url (session memory)
     @State private var detailArticle: Article?
     @State private var articleTextState: ArticleTextState = .loading
     @State private var keywordArticle: Article?      // article whose term to suggest; nil when opened without an article
@@ -1529,6 +1530,12 @@ struct ContentView: View {
             keywordState = .missingKey
             return
         }
+        // Reuse the session cache (keyed by article.url) so the same headline never re-runs Gemini.
+        if let cacheKey = article.url, let cached = keywordTermCache[cacheKey] {
+            keywordState = .loaded(cached)
+            keywordDraft = cached
+            return
+        }
         let description = article.description ?? ""
         let content = article.content ?? ""
         let input = "Headline: \(article.title)\nDescription: \(description)\nContent: \(content)"
@@ -1537,6 +1544,7 @@ struct ContentView: View {
             if term.isEmpty {
                 keywordState = .failed
             } else {
+                if let cacheKey = article.url { keywordTermCache[cacheKey] = term }
                 keywordState = .loaded(term)
                 keywordDraft = term   // pre-fill the input so the term is ready to edit/send
             }


### PR DESCRIPTION
The long-press key-term panel now caches its Gemini-extracted term per `article.url` in a session dictionary (`keywordTermCache`), mirroring the related-news drill-down's `spawnCache`. Reopening the panel for the same headline reuses the cached term — instant pre-fill, no repeat Gemini call. Session-memory only; no persistence across launches.

Verified via simulator build + physical-device deploy (first open shows the Gemini spinner; reopening the same headline pre-fills instantly).

Closes #133
