### PR TITLE
fix: cache recent-changes panel fallback (#136)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-14
 
+### fix: keep "Changes made this week" panel populated when GitHub fetch fails (issue #136)
+
+- `webapp/app/page.tsx`: the homepage "Changes made this week" panel now caches its last successful list in `localStorage` (`firstcontact:recent-changes:v1`) and renders it cache-first. The unauthenticated, browser-side GitHub fetch can fail on the anonymous 60/hr rate limit (403) or a transient 5xx/offline blip; previously that blanked the panel to "Could not load recent changes." Now the fetch falls back to the cached list, and the error only shows when there is no cache. New `readRecentCache`/`writeRecentCache` helpers mirror the 30-day-summary cache; the cache is written only on a non-empty success.
+- `webapp/TEST-PLAN.md`: added § 19 covering cache-first render, failure fallback, corrupted-cache tolerance, and code-shape guards.
+
 ### feat: cache key-term panel's Gemini result per article (issue #133)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: the long-press key-term panel (`loadKeyword`) now caches its Gemini-extracted term per `article.url` in a new `keywordTermCache` session dictionary, mirroring the drill-down's `spawnCache`. Reopening the panel for the same headline reuses the cached term (instant pre-fill, no spinner) instead of re-running Gemini; the term is stored on first successful extraction. Session-memory only — no persistence across launches.

--- a/webapp/TEST-PLAN.md
+++ b/webapp/TEST-PLAN.md
@@ -1110,6 +1110,44 @@ Implementation: a single change inside `render(index)` in [web/transcripts-viewe
 | 18c.2 | `grep -nF 'p.user_text || ' web/transcripts-viewer.html` | Exactly one match — the same line. No other code path bypasses the first-line collapse for the prompt-line. |
 | 18c.3 | Read the two `buildPromptLine(...)` calls in `render(index)`. | Both branches pass the same `userText` variable. Neither re-derives a multi-line version. |
 
+## 19. "Changes made this week" last-known-good cache (issue #136)
+
+Issue #136 makes the homepage "Changes made this week" panel resilient to a failing GitHub fetch. The fetch is unauthenticated and browser-side, so it can fail on the anonymous 60/hr rate limit (403) or a transient 5xx/offline blip — previously that blanked the panel to "Could not load recent changes." Now the panel caches its last successful list in `localStorage` (key `firstcontact:recent-changes:v1`), renders it immediately on mount, and falls back to it on fetch failure; the error message only shows when there is no cache.
+
+Implementation: `readRecentCache`/`writeRecentCache` helpers in [app/page.tsx](app/page.tsx) (mirroring the 30-day-summary `readCache`/`writeCache`), and a rewritten recent-changes `useEffect` — cache-first render, `writeRecentCache(recent)` on a non-empty success, and a `catch` that only sets the `error` state when `cached` is null.
+
+### 19a. Cache-first render + revalidation
+
+| ID | Steps | Expected |
+|---|---|---|
+| 19a.1 | Fresh browser (no `firstcontact:recent-changes:v1` in Local Storage). Load `/`. | Panel shows "Loading…" briefly, then the live list of issues closed this week (PRs filtered out). Application → Local Storage now holds the key with an `items` array + `generated_at`. |
+| 19a.2 | With a populated cache, hard-refresh `/`. | Panel shows the cached list immediately (no "Loading…" flash), then updates in place when the live fetch resolves. |
+| 19a.3 | Fetch succeeds but returns no issues closed this week (override the `/issues` response to `[]` per Appendix E, or pick a quiet week). | Panel shows "No changes this week." The cache is **not** overwritten with an empty list (an empty success leaves the prior last-known-good intact). |
+
+### 19b. Failure fallback
+
+| ID | Steps | Expected |
+|---|---|---|
+| 19b.1 | With a populated cache, block `*api.github.com*` (Appendix C) and hard-refresh. | Panel shows the cached list. **No** "Could not load recent changes." message. No blank panel. |
+| 19b.2 | Same as 19b.1 but with the Network throttle set to **Offline** (Appendix D). | Same as 19b.1 — cached list shown, no error. |
+| 19b.3 | Clear Local Storage (no cache), then block `*api.github.com*` and hard-refresh. | Panel shows "Could not load recent changes." (the only path that still surfaces the error). |
+| 19b.4 | Override the `/issues` response to malformed JSON (Appendix E) with a populated cache. | Cached list shown, no error (parse failure is caught like any other). |
+
+### 19c. Corrupted / partial cache tolerance
+
+| ID | Steps | Expected |
+|---|---|---|
+| 19c.1 | Set `localStorage['firstcontact:recent-changes:v1'] = 'not json'` via console, then reload with the fetch blocked. | No JS error. `readRecentCache` returns null → "Could not load recent changes." (no cache to fall back to). |
+| 19c.2 | Set the key to `{"items":[{"id":1},{"title":"x"},{"id":2,"title":"ok"}]}` (mixed valid/invalid entries), reload with fetch blocked. | Only the well-formed entry (`id:2,"ok"`) renders; malformed entries are dropped by the type-guard filter. No error, no crash. |
+
+### 19d. Code-shape regression guards
+
+| ID | Steps | Expected |
+|---|---|---|
+| 19d.1 | `grep -nF 'firstcontact:recent-changes:v1' app/page.tsx` | Exactly one match — the `RECENT_STORAGE_KEY` constant. |
+| 19d.2 | `grep -nF 'writeRecentCache(recent)' app/page.tsx` | Exactly one match — inside the non-empty success branch only. The empty branch does not write the cache. |
+| 19d.3 | Read the recent-changes `useEffect` `catch` block. | It sets the `error` state only inside `if (!cached)`. With a cache present, the catch is a no-op (the cached list rendered before the fetch stays on screen). |
+
 ## Exit criteria
 
 A change ships when:

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -14,6 +14,7 @@ const wipText = (view: number) => `View ${view + 1}: Work in progress`;
 const SUMMARY_URL = "http://localhost:8001/summary/30days";
 const STORAGE_KEY = "firstcontact:summary-30d:v1";
 const TTL_HOURS = 24;
+const RECENT_STORAGE_KEY = "firstcontact:recent-changes:v1";
 
 type SummaryView1 = { prose: string; footnote: string | null };
 type RecentTask = { id: number; title: string };
@@ -51,6 +52,36 @@ function writeCache(summary: string) {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({ summary, generated_at: new Date().toISOString(), ttl_hours: TTL_HOURS })
+    );
+  } catch {
+    // quota exceeded / private browsing — degrade silently
+  }
+}
+
+// Last-known-good cache for the recent-changes list, so a transient GitHub API
+// failure (anonymous 60/hr rate limit, a 5xx, an offline blip) keeps showing the
+// last successful result instead of blanking the panel. Mirrors readCache above.
+function readRecentCache(): RecentTask[] | null {
+  try {
+    const raw = localStorage.getItem(RECENT_STORAGE_KEY);
+    if (!raw) return null;
+    const obj = JSON.parse(raw);
+    if (!Array.isArray(obj?.items)) return null;
+    const items: RecentTask[] = obj.items.filter(
+      (i: unknown): i is RecentTask =>
+        typeof (i as RecentTask)?.id === "number" && typeof (i as RecentTask)?.title === "string"
+    );
+    return items.length ? items : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeRecentCache(items: RecentTask[]) {
+  try {
+    localStorage.setItem(
+      RECENT_STORAGE_KEY,
+      JSON.stringify({ items, generated_at: new Date().toISOString() })
     );
   } catch {
     // quota exceeded / private browsing — degrade silently
@@ -127,7 +158,16 @@ export default function HomePage() {
   }, []);
 
   // Changes made this week, from closed GitHub issues (PRs filtered out).
+  // Cache-first: show last-known-good immediately, then revalidate. The fetch is
+  // unauthenticated and browser-side, so it can fail on the anonymous 60/hr rate
+  // limit or a transient blip — fall back to the cached list rather than blanking.
   useEffect(() => {
+    const showItems = (items: RecentTask[]) =>
+      setRecentTasksState({ kind: "ready", items, message: null });
+
+    const cached = readRecentCache();
+    if (cached) showItems(cached);
+
     (async () => {
       try {
         const res = await fetch(
@@ -149,14 +189,18 @@ export default function HomePage() {
         if (recent.length === 0) {
           setRecentTasksState({ kind: "empty", items: [], message: "No changes this week." });
         } else {
-          setRecentTasksState({ kind: "ready", items: recent, message: null });
+          showItems(recent);
+          writeRecentCache(recent);
         }
       } catch {
-        setRecentTasksState({
-          kind: "error",
-          items: [],
-          message: "Could not load recent changes.",
-        });
+        // Keep the cached list shown above; only surface an error with no fallback.
+        if (!cached) {
+          setRecentTasksState({
+            kind: "error",
+            items: [],
+            message: "Could not load recent changes.",
+          });
+        }
       }
     })();
   }, []);


### PR DESCRIPTION
Makes the homepage "Changes made this week" panel resilient to a failing GitHub fetch. The fetch is unauthenticated and browser-side, so it can fail on the anonymous 60/hr rate limit (403) or a transient 5xx/offline blip — previously that blanked the panel to "Could not load recent changes." Now the last successful list is cached in `localStorage` (`firstcontact:recent-changes:v1`) and rendered cache-first; on fetch failure the panel falls back to the cached list, surfacing the error only when there is no cache. Mirrors the 30-day-summary panel's existing `readCache`/`writeCache` resilience. Adds TEST-PLAN § 19.

Verified: `npx eslint app/page.tsx` clean, `npm run build` clean (7 pages, routes unchanged).

Closes #136
