### PR TITLE
feat: embed GitHub treemap at /ghstars (#139)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-06-15
+
+### feat: embed GitHub treemap as /ghstars route in webapp (issue #139)
+
+- Ported the third-party **`xiaoxiunique/1k-github-stars`** treemap app into `webapp/` as a new client-rendered route at `/ghstars`, with prominent credit to the original author (header byline linking to the source repo).
+- `webapp/lib/treemap/*` + `webapp/components/treemap/*`: copied the source, namespaced under `treemap/`. `lib/treemap/data.ts` refactored from a build-time `import "@/data/repos.json"` into pure functions taking the fetched `RepoData`. `Treemap.tsx` drops `next/navigation` routing — language/tier drill and the Projects/Daily/Awesome tabs are now client state via new callbacks; `Header.tsx` tabs became buttons. Hover metadata fetch repointed to `github-treemap.pages.dev`.
+- `webapp/app/ghstars/{layout,page}.tsx`: client page fetches `/treemap-data/repos.json` on mount and degrades to a "dataset unavailable" empty state when absent (Vercel). Dark theme scoped via Tailwind on the page wrapper — `app/globals.css` untouched.
+- `webapp/app/page.tsx`: added a "GitHub Treemap →" homepage tool link.
+- `webapp/.gitignore`: ignore `public/treemap-data/` (the ~9.4 MB dataset is fetched at runtime, never committed). Known limitation: real data shows only in local `npm run dev`.
+- Docs: `webapp/CLAUDE.md` + `webapp/TEST-PLAN.md` (§ 20).
+
 ## 2026-06-14
 
 ### chore: bump Next.js 16.2.7 → 16.2.9 (issue #135)

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -40,3 +40,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# treemap dataset (issue #139) — large, fetched at runtime; not committed
+/public/treemap-data/
+
+# The repo-root .gitignore has a bare `lib/` (Python packaging) that also
+# matches webapp/lib — re-include our TypeScript source under webapp/lib/.
+!/lib/

--- a/webapp/CLAUDE.md
+++ b/webapp/CLAUDE.md
@@ -16,6 +16,25 @@ issue #88). It serves three things:
 - **Tool pages** (`public/digikey-search.html`, `mouser-search.html`,
   `transcripts-viewer.html`) — self-contained static HTML served verbatim by
   Next at `/digikey-search.html` etc. Not React; don't rewrite them.
+- **GitHub Treemap** (`app/ghstars/**`) — `/ghstars`, an interactive repo
+  treemap ported from the third-party **`xiaoxiunique/1k-github-stars`** app
+  (issue #139), with prominent credit to the original author. Source lives under
+  `components/treemap/` + `lib/treemap/`; it's a client island (`page.tsx` is
+  `"use client"`) that fetches its dataset at runtime — `lib/treemap/data.ts`
+  was refactored from a build-time `import` into pure functions taking the
+  fetched `RepoData`. The upstream's separate routes (`/awesome`,
+  `/daily-trading`, `/[lang]`) are collapsed into client state (tabs + drill).
+  Its dark theme is scoped to the route via Tailwind classes — **don't** import
+  the upstream `globals.css` (the light-theme webapp `app/globals.css` stays
+  untouched). Hover metadata is fetched from `github-treemap.pages.dev`.
+
+## Treemap dataset (gitignored)
+
+`/ghstars` fetches `public/treemap-data/repos.json` (~9.4 MB) at runtime. That
+folder is **gitignored** — copy `repos.json` there from a `1k-github-stars`
+checkout for local dev. Because it's never committed, it's absent on Vercel, so
+`/ghstars` shows a graceful "dataset unavailable" empty state in production until
+data hosting is wired up. Don't commit the dataset.
 
 > ⚠️ Next 16 has breaking changes vs. older versions (see [AGENTS.md](AGENTS.md)).
 > Consult `node_modules/next/dist/docs/` before touching framework wiring.

--- a/webapp/TEST-PLAN.md
+++ b/webapp/TEST-PLAN.md
@@ -1148,6 +1148,47 @@ Implementation: `readRecentCache`/`writeRecentCache` helpers in [app/page.tsx](a
 | 19d.2 | `grep -nF 'writeRecentCache(recent)' app/page.tsx` | Exactly one match — inside the non-empty success branch only. The empty branch does not write the cache. |
 | 19d.3 | Read the recent-changes `useEffect` `catch` block. | It sets the `error` state only inside `if (!cached)`. With a cache present, the catch is a no-op (the cached list rendered before the fetch stays on screen). |
 
+## 20. GitHub Treemap embed at `/ghstars` (issue #139)
+
+Issue #139 ports the third-party `xiaoxiunique/1k-github-stars` treemap into the webapp as a client-rendered route at `/ghstars`, fetching its dataset at runtime. Source under `components/treemap/` + `lib/treemap/`; `lib/treemap/data.ts` is pure functions over a fetched `RepoData`; tabs + language/tier drill are client state (no router). Dataset (`public/treemap-data/repos.json`) is gitignored — present in `npm run dev`, absent on Vercel (graceful empty state).
+
+### 20a. Route + data loading
+
+| ID | Steps | Expected |
+|---|---|---|
+| 20a.1 | `npm run dev`, open `/ghstars` with `public/treemap-data/repos.json` present. | Brief "Loading treemap…", then the interactive treemap renders (language blocks sized by stars). |
+| 20a.2 | DevTools Network: confirm the dataset request. | `GET /treemap-data/repos.json` → 200. |
+| 20a.3 | Remove/rename `public/treemap-data/repos.json` (simulate Vercel), hard-refresh. | "Treemap dataset unavailable" empty state. No crash, no console error thrown past the caught fetch. |
+| 20a.4 | From the homepage, click "GitHub Treemap →". | Navigates to `/ghstars`. |
+
+### 20b. Views, drill-down, search
+
+| ID | Steps | Expected |
+|---|---|---|
+| 20b.1 | Click the **Daily** then **Awesome** then **Projects** tabs. | View switches each time; breadcrumb/info line update; drill state resets to overview. |
+| 20b.2 | Click a language block in overview. | Drills into that language (detail mode); breadcrumb shows `All Languages › <Lang>`. |
+| 20b.3 | In a language detail with >36 repos, click a tier header / "More". | Drills into the tier; breadcrumb shows `All Languages › <Lang> › <tier>`. |
+| 20b.4 | Click "All Languages" (and the `<Lang>` crumb) in the breadcrumb. | Returns to overview (resp. back one level to the language). |
+| 20b.5 | Type in the Search box. | Treemap filters to matching repos; `?q=` reflects in the URL; "No repositories match" shown when empty. |
+| 20b.6 | Switch metric Stars/30d Growth/Forks (Projects view). | Block sizes re-layout by the chosen metric. Daily view has no metric switcher (growth-only). |
+| 20b.7 | Hover a repo rectangle. | Tooltip shows repo metadata; created/updated dates load (fetched from `github-treemap.pages.dev/repo-meta.json`). |
+| 20b.8 | Click a repo rectangle. | Opens `https://github.com/<owner/repo>` in a new tab. |
+
+### 20c. Isolation + credit
+
+| ID | Steps | Expected |
+|---|---|---|
+| 20c.1 | Visit `/` (homepage) after visiting `/ghstars`. | Homepage retains its light theme — the treemap's dark styling did not leak (no upstream `globals.css` import). |
+| 20c.2 | Inspect the `/ghstars` header. | A visible "Original by xiaoxiunique ↗" link to `https://github.com/xiaoxiunique/1k-github-stars`. |
+
+### 20d. Code-shape regression guards
+
+| ID | Steps | Expected |
+|---|---|---|
+| 20d.1 | `grep -rnF '@/data/repos.json' lib/treemap components/treemap app/ghstars` | No matches — no build-time dataset import remains. |
+| 20d.2 | `grep -rnF 'next/navigation' components/treemap` | No matches — routing replaced by client-state callbacks. |
+| 20d.3 | `grep -nF 'public/treemap-data/' .gitignore` | One match — the dataset dir is gitignored. |
+
 ## Exit criteria
 
 A change ships when:

--- a/webapp/app/ghstars/layout.tsx
+++ b/webapp/app/ghstars/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "GitHub Treemap",
+  description:
+    "Interactive treemap of top GitHub repositories by language, stars, growth, and curated lists. Embedded from xiaoxiunique/1k-github-stars.",
+};
+
+// The treemap renders full-viewport with its own dark theme via Tailwind classes
+// on the page wrapper, so this layout only supplies the route's <title> and
+// passes children through. It does NOT redefine <html>/<body> (that's the root
+// layout's job) and does NOT import the upstream globals.css (the light-theme
+// webapp globals stay untouched — the components use inline/Tailwind colors).
+export default function GhStarsLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return <>{children}</>;
+}

--- a/webapp/app/ghstars/page.tsx
+++ b/webapp/app/ghstars/page.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Treemap } from "@/components/treemap/Treemap";
+import type { TreemapView } from "@/components/treemap/Header";
+import {
+  DAILY_TRENDING_MIN_BASELINE_STARS,
+  DAILY_TRENDING_MIN_REPO_AGE_DAYS,
+  getCuratedGroups,
+  getCuratedTotal,
+  getDailyTrendingData,
+  getExportedAt,
+  getGroups,
+  getTotal,
+} from "@/lib/treemap/data";
+import { filterReposByTier, parseTierSlug } from "@/lib/treemap/tiers";
+import type { GroupData, Metric, RepoData } from "@/lib/treemap/types";
+
+// Dataset is fetched at runtime from public/treemap-data/ (gitignored — present
+// in `npm run dev`, absent on Vercel where this 404s into the empty state).
+const DATA_URL = "/treemap-data/repos.json";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "ready"; data: RepoData };
+
+function formatExportedAt(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  }).format(new Date(value));
+}
+
+function formatBaseThreshold(value: number) {
+  if (value >= 1000) {
+    const compact = value / 1000;
+    return Number.isInteger(compact) ? `${compact}k` : `${compact.toFixed(1)}k`;
+  }
+  return String(value);
+}
+
+function tierLabelFor(min: number, max: number) {
+  const fmt = (v: number) =>
+    v === Infinity ? "∞" : v >= 1000 ? `${v / 1000}k` : `${v}`;
+  return `★ ${fmt(min)}–${fmt(max)}`;
+}
+
+export default function GhStarsPage() {
+  const [load, setLoad] = useState<LoadState>({ status: "loading" });
+
+  // View + drill navigation are client state (single route, no router).
+  const [view, setView] = useState<TreemapView>("projects");
+  const [langName, setLangName] = useState<string | null>(null);
+  const [tierSlug, setTierSlug] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const apply = (next: LoadState) => {
+      if (!cancelled) setLoad(next);
+    };
+    (async () => {
+      try {
+        const res = await fetch(DATA_URL);
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        const data = (await res.json()) as RepoData;
+        if (!Array.isArray(data?.repos) || !Array.isArray(data?.langs)) {
+          throw new Error("malformed dataset");
+        }
+        apply({ status: "ready", data });
+      } catch {
+        apply({ status: "error" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const data = load.status === "ready" ? load.data : null;
+
+  // Base groups + headline numbers for the active view.
+  const viewModel = useMemo(() => {
+    if (!data) return null;
+    if (view === "awesome") {
+      return {
+        groups: getCuratedGroups(data),
+        total: getCuratedTotal(data),
+        exportedAt: getExportedAt(data),
+        daily: null as ReturnType<typeof getDailyTrendingData> | null,
+      };
+    }
+    if (view === "daily") {
+      const daily = getDailyTrendingData(data);
+      return { groups: daily.groups, total: daily.positiveGrowthRepoCount, exportedAt: getExportedAt(data), daily };
+    }
+    return { groups: getGroups(data), total: getTotal(data), exportedAt: getExportedAt(data), daily: null };
+  }, [data, view]);
+
+  const navHandlers = {
+    onViewChange: (v: TreemapView) => {
+      setView(v);
+      setLangName(null);
+      setTierSlug(null);
+    },
+    onOpenLang: (name: string) => {
+      setLangName(name);
+      setTierSlug(null);
+    },
+    onOpenTier: (slug: string) => setTierSlug(slug),
+    onBackToOverview: () => {
+      setLangName(null);
+      setTierSlug(null);
+    },
+    onBackToLang: () => setTierSlug(null),
+  };
+
+  let body: React.ReactNode;
+
+  if (load.status === "loading") {
+    body = <StatusScreen title="Loading treemap…" />;
+  } else if (load.status === "error" || !viewModel) {
+    body = (
+      <StatusScreen
+        title="Treemap dataset unavailable"
+        detail="The repo dataset isn't bundled in this deployment. Run the app locally (npm run dev) with public/treemap-data/repos.json present to explore the treemap."
+      />
+    );
+  } else {
+    const selectedGroup: GroupData | undefined = langName
+      ? viewModel.groups.find((g) => g.lang === langName)
+      : undefined;
+
+    // Shared metric config — daily ranks by growth with no metric switcher.
+    const metricProps =
+      view === "daily"
+        ? {
+            initialMetric: "growth" as Metric,
+            availableMetrics: [] as Metric[],
+            fallbackMetric: "stars" as Metric,
+            fallbackNotice: {
+              title: "No eligible growth rows in the current dataset",
+              detail: `This view only includes repos at least ${DAILY_TRENDING_MIN_REPO_AGE_DAYS} days old with at least ${formatBaseThreshold(DAILY_TRENDING_MIN_BASELINE_STARS)} stars before the current growth window. It falls back to stars for the same eligible pool.`,
+            },
+          }
+        : {};
+
+    if (selectedGroup && tierSlug) {
+      // Tier drill within a language.
+      const range = parseTierSlug(tierSlug);
+      const tierRepos = range
+        ? filterReposByTier(selectedGroup.repos, range.min, range.max)
+        : [];
+      const tierGroup: GroupData = {
+        lang: selectedGroup.lang,
+        color: selectedGroup.color,
+        count: tierRepos.length,
+        total: tierRepos.reduce((s, r) => s + r.stars, 0),
+        repos: tierRepos,
+      };
+      body = (
+        <Treemap
+          key={`${view}|${langName}|${tierSlug}`}
+          mode="detail"
+          detailGroup={tierGroup}
+          total={viewModel.total}
+          tierLabel={range ? tierLabelFor(range.min, range.max) : undefined}
+          activeView={view}
+          {...navHandlers}
+          {...metricProps}
+        />
+      );
+    } else if (selectedGroup) {
+      // Language detail.
+      body = (
+        <Treemap
+          key={`${view}|${langName}`}
+          mode="detail"
+          detailGroup={selectedGroup}
+          total={viewModel.total}
+          activeView={view}
+          {...navHandlers}
+          {...metricProps}
+        />
+      );
+    } else {
+      // Overview for the active view.
+      const overrides =
+        view === "awesome"
+          ? {
+              breadcrumbOverride: [
+                { label: "All Languages", onClick: () => navHandlers.onViewChange("projects") },
+                { label: "Awesome / Guides", color: "#8eea54" },
+              ],
+              infoOverride: `${formatExportedAt(viewModel.exportedAt)} UTC · ${viewModel.total.toLocaleString()} curated repos`,
+            }
+          : view === "daily" && viewModel.daily
+            ? {
+                breadcrumbOverride: [
+                  { label: "All Languages", onClick: () => navHandlers.onViewChange("projects") },
+                  { label: "Daily Trending", color: "#61dafb" },
+                ],
+                infoOverride: `${formatExportedAt(viewModel.exportedAt)} UTC · ${viewModel.daily.positiveGrowthRepoCount.toLocaleString()} growing repos · ${viewModel.daily.eligibleRepoCount.toLocaleString()} eligible · ${DAILY_TRENDING_MIN_REPO_AGE_DAYS}d+ old · ${formatBaseThreshold(DAILY_TRENDING_MIN_BASELINE_STARS)}+ base`,
+              }
+            : {};
+      body = (
+        <Treemap
+          key={view}
+          mode="overview"
+          groups={viewModel.groups}
+          total={viewModel.total}
+          activeView={view}
+          {...navHandlers}
+          {...metricProps}
+          {...overrides}
+        />
+      );
+    }
+  }
+
+  return (
+    <main className="flex flex-col h-screen bg-[#0c0c0c] text-white overflow-hidden">
+      {body}
+    </main>
+  );
+}
+
+function StatusScreen({ title, detail }: { title: string; detail?: string }) {
+  return (
+    <div className="flex-1 flex items-center justify-center px-6 text-center">
+      <div className="max-w-md rounded-2xl border border-white/10 bg-black/40 px-5 py-4 backdrop-blur-md">
+        <div className="text-base font-semibold text-white">{title}</div>
+        {detail && <div className="mt-1 text-sm text-neutral-400">{detail}</div>}
+      </div>
+    </div>
+  );
+}

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -303,6 +303,7 @@ export default function HomePage() {
 
       <nav className={styles.toolLinks} aria-label="Tools">
         <Link className={styles.toolLink} href="/news">Latest News →</Link>
+        <Link className={styles.toolLink} href="/ghstars">GitHub Treemap →</Link>
         <a className={styles.toolLink} href="/digikey-search.html">DigiKey search →</a>
         <a className={styles.toolLink} href="/mouser-search.html">Mouser search →</a>
         <a className={styles.toolLink} href="/transcripts-viewer.html">Transcripts viewer →</a>

--- a/webapp/components/treemap/Header.tsx
+++ b/webapp/components/treemap/Header.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { Metric } from "@/lib/treemap/types";
+
+export type TreemapView = "projects" | "daily" | "awesome";
+
+export interface HeaderBreadcrumbItem {
+  label: string;
+  onClick?: () => void;
+  color?: string;
+}
+
+interface HeaderProps {
+  breadcrumb?: HeaderBreadcrumbItem[];
+  metric: Metric;
+  onMetricChange: (m: Metric) => void;
+  search: string;
+  onSearchChange: (v: string) => void;
+  info: string;
+  metrics?: { key: Metric; label: string }[];
+  activeView: TreemapView;
+  onViewChange: (v: TreemapView) => void;
+}
+
+const DEFAULT_METRICS: { key: Metric; label: string }[] = [
+  { key: "stars", label: "Stars" },
+  { key: "growth", label: "30d Growth" },
+  { key: "forks", label: "Forks" },
+];
+
+const GLOBAL_TABS: { view: TreemapView; label: string }[] = [
+  { view: "projects", label: "Projects" },
+  { view: "daily", label: "Daily" },
+  { view: "awesome", label: "Awesome" },
+];
+
+// Original treemap by xiaoxiunique — credit preserved (the upstream repo ships
+// no LICENSE; this embed links back to the source prominently).
+const SOURCE_REPO_URL = "https://github.com/xiaoxiunique/1k-github-stars";
+
+export function Header({
+  breadcrumb,
+  metric,
+  onMetricChange,
+  search,
+  onSearchChange,
+  info,
+  metrics = DEFAULT_METRICS,
+  activeView,
+  onViewChange,
+}: HeaderProps) {
+  return (
+    <header className="flex items-center gap-3 px-5 py-2.5 bg-[#151515] border-b border-[#252525] shrink-0 z-10">
+      <h1 className="text-[15px] font-bold whitespace-nowrap">
+        GitHub <span className="text-[#61dafb]">Treemap</span>
+      </h1>
+
+      <div className="flex gap-1">
+        {GLOBAL_TABS.map((tab) => {
+          const active = tab.view === activeView;
+          return (
+            <button
+              key={tab.view}
+              onClick={() => onViewChange(tab.view)}
+              className={`px-3 py-1 rounded text-xs border transition-all cursor-pointer ${
+                active
+                  ? "bg-[#61dafb] text-black border-[#61dafb]"
+                  : "border-[#252525] text-neutral-500 hover:border-neutral-600 hover:text-neutral-300"
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <a
+        href={SOURCE_REPO_URL}
+        target="_blank"
+        rel="noreferrer"
+        title="Original treemap by xiaoxiunique — view source on GitHub"
+        className="px-3 py-1 rounded text-xs border border-[#252525] text-neutral-500 hover:border-neutral-600 hover:text-neutral-300 transition-all whitespace-nowrap"
+      >
+        Original by xiaoxiunique ↗
+      </a>
+
+      <nav className="flex items-center gap-1 text-sm text-neutral-500">
+        {breadcrumb?.map((b, i) => (
+          <span key={i} className="flex items-center gap-1">
+            {i > 0 && <span className="opacity-40 mx-0.5">›</span>}
+            {b.onClick ? (
+              <button
+                onClick={b.onClick}
+                className="text-[#61dafb] hover:underline cursor-pointer"
+              >
+                {b.label}
+              </button>
+            ) : (
+              <span style={b.color ? { color: b.color, fontWeight: 600 } : undefined}>
+                {b.label}
+              </span>
+            )}
+          </span>
+        ))}
+      </nav>
+
+      {metrics.length > 0 && (
+        <div className="flex gap-1 ml-3">
+          {metrics.map((m) => (
+            <button
+              key={m.key}
+              onClick={() => onMetricChange(m.key)}
+              className={`px-3 py-1 rounded text-xs border transition-all cursor-pointer ${
+                metric === m.key
+                  ? "bg-white text-black border-white"
+                  : "border-[#252525] text-neutral-500 hover:border-neutral-600 hover:text-neutral-300"
+              }`}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => onSearchChange(e.target.value)}
+        placeholder="Search..."
+        className="ml-auto px-2.5 py-1 rounded text-xs border border-[#252525] bg-[#0c0c0c] text-neutral-200 outline-none w-44 focus:border-neutral-600"
+      />
+
+      <span className="text-xs text-neutral-500 whitespace-nowrap">{info}</span>
+    </header>
+  );
+}

--- a/webapp/components/treemap/Panel.tsx
+++ b/webapp/components/treemap/Panel.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useRef, forwardRef, useImperativeHandle } from "react";
+import type { Repo } from "@/lib/treemap/types";
+import { fmtK } from "@/lib/treemap/colors";
+
+interface PanelProps {
+  title: string;
+  subtitle: string;
+  color: string;
+  repos: Repo[];
+  startRank: number;
+}
+
+export interface PanelHandle {
+  show: (x: number, y: number, props: PanelProps) => void;
+  hide: () => void;
+}
+
+export const Panel = forwardRef<PanelHandle>(function Panel(_, ref) {
+  const elRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    show(x: number, y: number, props: PanelProps) {
+      const el = elRef.current;
+      if (!el) return;
+
+      el.querySelector<HTMLDivElement>(".p-dot")!.style.background = props.color;
+      el.querySelector<HTMLDivElement>(".p-title")!.textContent = props.title;
+      el.querySelector<HTMLDivElement>(".p-meta")!.textContent = props.subtitle;
+
+      const list = el.querySelector<HTMLDivElement>(".p-list")!;
+      list.innerHTML = props.repos
+        .slice(0, 30)
+        .map((repo, i) => {
+          const [owner, name] = repo.fullName.split("/");
+          const growth = repo.growth > 0 ? `+${fmtK(repo.growth)}` : "—";
+          const gc = repo.growth > 0 ? "text-green-400" : "text-neutral-600";
+          return `<a href="https://github.com/${repo.fullName}" target="_blank"
+            class="flex items-center gap-2.5 px-4 py-1.5 hover:bg-white/5 cursor-pointer text-sm">
+            <span class="text-xs text-neutral-600 w-5 text-right shrink-0">${props.startRank + i}</span>
+            <span class="font-semibold truncate flex-1">${name}</span>
+            <span class="text-xs text-neutral-500 truncate max-w-20 shrink-0">${owner}</span>
+            <span class="text-xs text-neutral-500 w-14 text-right shrink-0">★ ${fmtK(repo.stars)}</span>
+            <span class="text-xs w-14 text-right shrink-0 ${gc}">${growth}</span>
+          </a>`;
+        })
+        .join("");
+
+      el.style.display = "block";
+      let px = x + 20,
+        py = y - 100;
+      if (px + 380 > window.innerWidth) px = x - 400;
+      if (py < 10) py = 10;
+      const h = el.offsetHeight;
+      if (py + h > window.innerHeight - 10) py = window.innerHeight - h - 10;
+      el.style.left = px + "px";
+      el.style.top = py + "px";
+    },
+    hide() {
+      if (elRef.current) elRef.current.style.display = "none";
+    },
+  }));
+
+  return (
+    <div
+      ref={elRef}
+      className="fixed z-50 hidden w-[380px] max-h-[70vh] bg-[rgba(12,12,12,0.96)] border border-white/10 rounded-xl backdrop-blur-xl shadow-2xl overflow-hidden"
+    >
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-white/5">
+        <div className="p-dot w-3 h-3 rounded-sm shrink-0" />
+        <div className="p-title font-bold text-sm" />
+        <div className="p-meta text-xs text-neutral-500 ml-auto" />
+      </div>
+      <div className="p-list overflow-y-auto max-h-[calc(70vh-50px)]" />
+      <div className="text-xs text-neutral-600 text-center py-2 border-t border-white/5">
+        Click repo to open GitHub
+      </div>
+    </div>
+  );
+});

--- a/webapp/components/treemap/Tooltip.tsx
+++ b/webapp/components/treemap/Tooltip.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useRef, forwardRef, useImperativeHandle } from "react";
+import type { Repo } from "@/lib/treemap/types";
+import { fmtK } from "@/lib/treemap/colors";
+
+export interface TooltipHandle {
+  show: (
+    x: number,
+    y: number,
+    repo: Repo,
+    langName: string,
+    langColor: string,
+    options?: { metaLoading?: boolean }
+  ) => void;
+  hide: () => void;
+}
+
+function formatDate(value?: string, loading = false) {
+  if (!value) return loading ? "Loading..." : "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return loading ? "Loading..." : "—";
+  return date.toISOString().slice(0, 10);
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export const Tooltip = forwardRef<TooltipHandle>(function Tooltip(_, ref) {
+  const elRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    show(x, y, repo, langName, langColor, options) {
+      const el = elRef.current;
+      if (!el) return;
+      const [owner, name] = repo.fullName.split("/");
+      const growth =
+        repo.growth > 0
+          ? `<span class="text-green-400">+${fmtK(repo.growth)}</span>`
+          : "—";
+      const createdAt = formatDate(repo.createdAt, options?.metaLoading);
+      const updatedAt = formatDate(repo.updatedAt, options?.metaLoading);
+      const safeName = escapeHtml(name);
+      const safeOwner = escapeHtml(owner);
+      const safeLangName = escapeHtml(langName);
+      const safeDescription = repo.description ? escapeHtml(repo.description) : "";
+      const safeCreatedAt = escapeHtml(createdAt);
+      const safeUpdatedAt = escapeHtml(updatedAt);
+
+      el.innerHTML = `
+        <div class="font-bold text-[15px] mb-0.5">${safeName}</div>
+        <div class="text-xs text-neutral-500 mb-1.5">${safeOwner}</div>
+        ${safeDescription ? `<div class="text-xs text-neutral-400 leading-relaxed mb-2">${safeDescription}</div>` : ""}
+        <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs">
+          <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full inline-block" style="background:${langColor}"></span>${safeLangName}</span>
+          <span>★ ${fmtK(repo.stars)}</span>
+          <span>⑂ ${fmtK(repo.forks)}</span>
+          <span>Growth: ${growth}</span>
+        </div>
+        <div class="mt-2 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs text-neutral-400">
+          <span class="text-neutral-500">Created</span>
+          <span>${safeCreatedAt}</span>
+          <span class="text-neutral-500">Updated</span>
+          <span>${safeUpdatedAt}</span>
+        </div>`;
+
+      el.style.display = "block";
+      let tx = x + 16,
+        ty = y + 16;
+      if (tx + 380 > window.innerWidth) tx = x - 390;
+      const height = el.offsetHeight || 180;
+      if (ty + height > window.innerHeight) ty = y - height - 16;
+      el.style.left = tx + "px";
+      el.style.top = ty + "px";
+    },
+    hide() {
+      if (elRef.current) elRef.current.style.display = "none";
+    },
+  }));
+
+  return (
+    <div
+      ref={elRef}
+      className="fixed z-50 hidden pointer-events-none max-w-[380px] bg-[rgba(10,10,10,0.92)] border border-white/10 rounded-xl px-4 py-3 backdrop-blur-2xl shadow-2xl"
+    />
+  );
+});

--- a/webapp/components/treemap/Treemap.tsx
+++ b/webapp/components/treemap/Treemap.tsx
@@ -1,0 +1,1130 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { squarify } from "@/lib/treemap/squarify";
+import { lighten, darken, contrastText, fmtK } from "@/lib/treemap/colors";
+import { getRepoValue } from "@/lib/treemap/metrics";
+import { Header, type HeaderBreadcrumbItem, type TreemapView } from "./Header";
+import { Panel, type PanelHandle } from "./Panel";
+import { Tooltip, type TooltipHandle } from "./Tooltip";
+import type { Repo, GroupData, Metric, RepoRect, GroupRect, Rect } from "@/lib/treemap/types";
+
+type SquarifyRect = {
+  rect?: Rect;
+};
+
+type GroupLayoutItem = SquarifyRect & {
+  val: number;
+  group: GroupData;
+};
+
+type TierGroup = {
+  label: string;
+  repos: Repo[];
+  total: number;
+};
+
+type TierLayoutItem = SquarifyRect & {
+  val: number;
+  group: TierGroup;
+};
+
+type RepoLayoutItem = SquarifyRect & {
+  val: number;
+  repo: Repo | null;
+  origIdx: number;
+};
+
+type RepoMeta = Pick<Repo, "createdAt" | "updatedAt">;
+
+type ActiveTooltip = {
+  fullName: string;
+  x: number;
+  y: number;
+  repo: Repo;
+  langName: string;
+  langColor: string;
+};
+
+type RepoMetaIndex = Record<string, [string | null, string | null]>;
+
+function matchesRepoSearch(repo: Repo, query: string, langName: string) {
+  if (!query) return true;
+
+  const normalizedLang = langName.toLowerCase();
+  const normalizedDescription = repo.description.toLowerCase();
+
+  return (
+    repo.fullName.toLowerCase().includes(query) ||
+    normalizedDescription.includes(query) ||
+    normalizedLang.includes(query)
+  );
+}
+
+// Dynamic tier computation based on data range
+function computeDynamicTiers(
+  minVal: number,
+  maxVal: number,
+  repos: Repo[],
+  getVal: (r: Repo) => number
+): { label: string; min: number; max: number }[] {
+  // Standard boundaries to try
+  const BOUNDARIES = [500000, 200000, 100000, 50000, 20000, 10000, 5000, 2000, 1000, 500, 200, 100, 0];
+  const relevant = BOUNDARIES.filter(b => b >= minVal && b <= maxVal + 1);
+
+  // Ensure we include minVal and maxVal+1
+  if (!relevant.includes(maxVal + 1) && maxVal + 1 > (relevant[0] || 0)) relevant.unshift(maxVal + 1);
+  if (relevant[relevant.length - 1] > minVal) relevant.push(minVal);
+
+  // Dedupe and sort descending
+  const bounds = [...new Set(relevant)].sort((a, b) => b - a);
+
+  if (bounds.length < 2) {
+    // Can't split meaningfully, force equal-count split
+    return forceEqualSplit(repos, getVal, 5);
+  }
+
+  const tiers: { label: string; min: number; max: number }[] = [];
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const max = bounds[i];
+    const min = bounds[i + 1];
+    const count = repos.filter(r => { const v = getVal(r); return v >= min && v < max; }).length;
+    if (count > 0) {
+      tiers.push({ label: `★ ${fmtK(min)}–${fmtK(max)}`, min, max });
+    }
+  }
+
+  return tiers.length >= 2 ? tiers : forceEqualSplit(repos, getVal, 5);
+}
+
+function forceEqualSplit(
+  repos: Repo[],
+  getVal: (r: Repo) => number,
+  chunks: number
+): { label: string; min: number; max: number }[] {
+  const sorted = [...repos].sort((a, b) => getVal(b) - getVal(a));
+  const chunkSize = Math.ceil(sorted.length / chunks);
+  const tiers: { label: string; min: number; max: number }[] = [];
+  for (let i = 0; i < sorted.length; i += chunkSize) {
+    const chunk = sorted.slice(i, i + chunkSize);
+    const hi = getVal(chunk[0]);
+    const lo = getVal(chunk[chunk.length - 1]);
+    tiers.push({ label: `★ ${fmtK(lo)}–${fmtK(hi)}`, min: lo, max: hi + 1 });
+  }
+  return tiers;
+}
+
+const METRIC_OPTIONS: Record<Metric, { key: Metric; label: string }> = {
+  stars: { key: "stars", label: "Stars" },
+  growth: { key: "growth", label: "30d Growth" },
+  forks: { key: "forks", label: "Forks" },
+};
+
+interface TreemapProps {
+  mode: "overview" | "detail";
+  groups?: GroupData[];
+  detailGroup?: GroupData;
+  total: number;
+  tierLabel?: string;
+  initialMetric?: Metric;
+  availableMetrics?: Metric[];
+  breadcrumbOverride?: HeaderBreadcrumbItem[];
+  infoOverride?: string;
+  fallbackMetric?: Metric;
+  fallbackNotice?: {
+    title: string;
+    detail: string;
+  };
+  // Navigation is client-state driven (single /ghstars route, no router). The
+  // parent owns view + lang/tier drill state and recomputes the props below.
+  activeView: TreemapView;
+  onViewChange: (v: TreemapView) => void;
+  onOpenLang?: (langName: string) => void;
+  onOpenTier?: (tierSlug: string) => void;
+  onBackToOverview?: () => void;
+  onBackToLang?: () => void;
+}
+
+export function Treemap({
+  mode,
+  groups,
+  detailGroup,
+  total,
+  tierLabel,
+  initialMetric = "stars",
+  availableMetrics = ["stars", "growth", "forks"],
+  breadcrumbOverride,
+  infoOverride,
+  fallbackMetric,
+  fallbackNotice,
+  activeView,
+  onViewChange,
+  onOpenLang,
+  onOpenTier,
+  onBackToOverview,
+  onBackToLang,
+}: TreemapProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<PanelHandle>(null);
+  const tooltipRef = useRef<TooltipHandle>(null);
+
+  const [metric, setMetric] = useState<Metric>(initialMetric);
+  const [search, setSearch] = useState("");
+  const [hasVisibleData, setHasVisibleData] = useState(true);
+  const [fallbackActive, setFallbackActive] = useState(false);
+
+  const rectsRef = useRef<RepoRect[]>([]);
+  const groupRectsRef = useRef<GroupRect[]>([]);
+  const hoveredIdxRef = useRef(-1);
+  const hoveredGroupRef = useRef(-1);
+  const allReposRef = useRef<Repo[]>([]); // for detail panel
+  const activeMetricRef = useRef<Metric>(initialMetric);
+  const tooltipMetaCacheRef = useRef<Map<string, RepoMeta>>(new Map());
+  const tooltipMetaIndexRequestRef = useRef<Promise<void> | null>(null);
+  const activeTooltipRef = useRef<ActiveTooltip | null>(null);
+  const searchReadyRef = useRef(false);
+
+  const metricOptions = availableMetrics.map((metricKey) => METRIC_OPTIONS[metricKey]);
+
+  const getMetricValue = useCallback((repo: Repo, metricKey: Metric) => getRepoValue(repo, metricKey), []);
+  const formatMetricValue = useCallback((metricKey: Metric, value: number) => {
+    if (metricKey === "growth") return `+${fmtK(value)}`;
+    if (metricKey === "forks") return `⑂ ${fmtK(value)}`;
+    return `★ ${fmtK(value)}`;
+  }, []);
+  const hideTooltip = useCallback(() => {
+    activeTooltipRef.current = null;
+    tooltipRef.current?.hide();
+  }, []);
+  const ensureTooltipMetaIndex = useCallback(() => {
+    if (tooltipMetaCacheRef.current.size > 0) {
+      return Promise.resolve();
+    }
+
+    if (tooltipMetaIndexRequestRef.current) {
+      return tooltipMetaIndexRequestRef.current;
+    }
+
+    // Hover metadata index lives on the upstream host (it's served from public/
+    // there). Fetched lazily on first hover; the .catch below degrades silently.
+    const request = fetch("https://github-treemap.pages.dev/repo-meta.json")
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load repo meta index: ${response.status}`);
+        }
+
+        const payload = (await response.json()) as RepoMetaIndex;
+        for (const [fullName, value] of Object.entries(payload)) {
+          tooltipMetaCacheRef.current.set(fullName, {
+            createdAt: value[0] ?? undefined,
+            updatedAt: value[1] ?? undefined,
+          });
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        tooltipMetaIndexRequestRef.current = null;
+      });
+
+    tooltipMetaIndexRequestRef.current = request;
+    return request;
+  }, []);
+  const showRepoTooltip = useCallback(
+    (x: number, y: number, repo: Repo, langName: string, langColor: string) => {
+      const cachedMeta = tooltipMetaCacheRef.current.get(repo.fullName);
+      const tooltipRepo = cachedMeta ? { ...repo, ...cachedMeta } : repo;
+
+      activeTooltipRef.current = {
+        fullName: repo.fullName,
+        x,
+        y,
+        repo,
+        langName,
+        langColor,
+      };
+
+      tooltipRef.current?.show(x, y, tooltipRepo, langName, langColor, {
+        metaLoading: !cachedMeta,
+      });
+
+      if (cachedMeta) {
+        return;
+      }
+
+      ensureTooltipMetaIndex().then(() => {
+        const meta = tooltipMetaCacheRef.current.get(repo.fullName);
+        if (!meta) return;
+
+        const activeTooltip = activeTooltipRef.current;
+        if (!activeTooltip || activeTooltip.fullName !== repo.fullName) return;
+
+        tooltipRef.current?.show(
+          activeTooltip.x,
+          activeTooltip.y,
+          { ...activeTooltip.repo, ...meta },
+          activeTooltip.langName,
+          activeTooltip.langColor
+        );
+      });
+    },
+    [ensureTooltipMetaIndex]
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const syncSearchFromUrl = () => {
+      const url = new URL(window.location.href);
+      const query = url.searchParams.get("q") ?? "";
+      setSearch(query);
+      searchReadyRef.current = true;
+    };
+
+    syncSearchFromUrl();
+    window.addEventListener("popstate", syncSearchFromUrl);
+
+    return () => {
+      window.removeEventListener("popstate", syncSearchFromUrl);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !searchReadyRef.current) return;
+
+    const url = new URL(window.location.href);
+    const query = search.trim();
+
+    if (query) {
+      url.searchParams.set("q", query);
+    } else {
+      url.searchParams.delete("q");
+    }
+
+    const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+    const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    if (nextUrl !== currentUrl) {
+      window.history.replaceState(window.history.state, "", nextUrl);
+    }
+  }, [search]);
+
+  // ── Compute layout ──
+  const computeLayout = useCallback(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+    const dpr = devicePixelRatio || 1;
+    const W = canvas.width / dpr;
+    const H = canvas.height / dpr;
+    const query = search.trim().toLowerCase();
+
+    if (mode === "overview" && groups) {
+      const searchedGroups = groups.map((g) => ({
+        ...g,
+        repos: query
+          ? g.repos.filter((r) => matchesRepoSearch(r, query, g.lang))
+          : g.repos,
+      }));
+      const hasSearchMatches = searchedGroups.some((g) => g.repos.length > 0);
+
+      const buildGroupsForMetric = (metricKey: Metric) =>
+        searchedGroups
+          .map((g) => {
+            const repos = [...g.repos]
+              .filter((repo) => getMetricValue(repo, metricKey) > 0)
+              .sort((a, b) => getMetricValue(b, metricKey) - getMetricValue(a, metricKey));
+            const filteredTotal = repos.reduce((sum, repo) => sum + getMetricValue(repo, metricKey), 0);
+            return { ...g, repos, total: filteredTotal, count: repos.length };
+          })
+          .filter((g) => g.total > 0)
+          .sort((a, b) => b.total - a.total);
+
+      let activeMetric = metric;
+      let filtered = buildGroupsForMetric(metric);
+      let shouldUseFallback = false;
+
+      if (hasSearchMatches && filtered.length === 0 && fallbackMetric) {
+        const fallbackGroups = buildGroupsForMetric(fallbackMetric);
+        if (fallbackGroups.length > 0) {
+          filtered = fallbackGroups;
+          activeMetric = fallbackMetric;
+          shouldUseFallback = true;
+        }
+      }
+
+      activeMetricRef.current = activeMetric;
+      setFallbackActive(shouldUseFallback);
+      setHasVisibleData(hasSearchMatches && filtered.length > 0);
+
+      if (!hasSearchMatches || filtered.length === 0) {
+        groupRectsRef.current = [];
+        rectsRef.current = [];
+        return;
+      }
+
+      const gItems: GroupLayoutItem[] = filtered.map((g) => ({
+        val: g.total,
+        group: g,
+      }));
+      squarify(gItems, 0, 0, W, H);
+
+      const newGroupRects: GroupRect[] = [];
+      const newRects: RepoRect[] = [];
+
+      for (const gi of gItems) {
+        if (!gi.rect) continue;
+        const g = gi.group;
+        const GAP = 1.5;
+        const HEADER_H = Math.min(22, Math.max(14, gi.rect.h * 0.06));
+
+        newGroupRects.push({
+          ...gi.rect,
+          lang: g.lang,
+          color: g.color,
+          count: g.count,
+          total: g.total,
+          headerH: HEADER_H,
+          allRepos: g.repos,
+        });
+
+        const ix = gi.rect.x + GAP;
+        const iy = gi.rect.y + HEADER_H + GAP;
+        const iw = gi.rect.w - GAP * 2;
+        const ih = gi.rect.h - HEADER_H - GAP * 2;
+
+        if (iw > 5 && ih > 5) {
+          const TOP_N = Math.min(6, g.repos.length);
+          const SMALL_MAX = 30;
+          const totalShow = Math.min(g.repos.length, TOP_N + SMALL_MAX);
+          const shown: RepoLayoutItem[] = g.repos.slice(0, totalShow).map((r, idx) => ({
+            val: getMetricValue(r, activeMetric),
+            repo: r,
+            origIdx: idx,
+          }));
+
+          if (g.repos.length > totalShow) {
+            const shownTotal = shown.reduce((s, it) => s + it.val, 0);
+            shown.push({
+              val: shownTotal * 0.15,
+              repo: null,
+              origIdx: -1,
+            });
+          }
+
+          squarify(shown, ix, iy, iw, ih);
+          for (let si = 0; si < shown.length; si++) {
+            const it = shown[si];
+            if (!it.rect) continue;
+            const isOthers = it.origIdx === -1;
+            newRects.push({
+              ...it.rect,
+              idx: isOthers ? -1 : it.origIdx,
+              groupIdx: newGroupRects.length - 1,
+              isOthers,
+              othersCount: isOthers ? g.repos.length - totalShow : 0,
+            });
+          }
+        }
+      }
+      groupRectsRef.current = newGroupRects;
+      rectsRef.current = newRects;
+    } else if (mode === "detail" && detailGroup) {
+      const searchedRepos = query
+        ? detailGroup.repos.filter((r) =>
+            matchesRepoSearch(r, query, detailGroup.lang)
+          )
+        : detailGroup.repos;
+      const buildReposForMetric = (metricKey: Metric) =>
+        [...searchedRepos]
+          .filter((repo) => getMetricValue(repo, metricKey) > 0)
+          .sort((a, b) => getMetricValue(b, metricKey) - getMetricValue(a, metricKey));
+
+      let activeMetric = metric;
+      let sorted = buildReposForMetric(metric);
+      let shouldUseFallback = false;
+
+      if (searchedRepos.length > 0 && sorted.length === 0 && fallbackMetric) {
+        const fallbackRepos = buildReposForMetric(fallbackMetric);
+        if (fallbackRepos.length > 0) {
+          sorted = fallbackRepos;
+          activeMetric = fallbackMetric;
+          shouldUseFallback = true;
+        }
+      }
+
+      activeMetricRef.current = activeMetric;
+      setFallbackActive(shouldUseFallback);
+      allReposRef.current = sorted;
+      setHasVisibleData(searchedRepos.length > 0 && sorted.length > 0);
+
+      if (searchedRepos.length === 0 || sorted.length === 0) {
+        rectsRef.current = [];
+        groupRectsRef.current = [];
+        return;
+      }
+
+      // If few enough repos, show flat (no grouping needed)
+      const MAX_FLAT = 36;
+      if (sorted.length <= MAX_FLAT) {
+        // Flat layout — all repos as individual cells
+        const shown: RepoLayoutItem[] = sorted.map((r, idx) => ({
+          val: getMetricValue(r, activeMetric),
+          repo: r,
+          origIdx: idx,
+        }));
+        squarify(shown, 0, 0, W, H);
+        const newRects: RepoRect[] = [];
+        for (const it of shown) {
+          if (it.rect) newRects.push({ ...it.rect, idx: it.origIdx });
+        }
+        rectsRef.current = newRects;
+        groupRectsRef.current = [];
+      } else {
+        // Dynamic tier grouping based on actual data range
+        const metricGetter = (repo: Repo) => getMetricValue(repo, activeMetric);
+        const maxVal = metricGetter(sorted[0]);
+        const minVal = metricGetter(sorted[sorted.length - 1]);
+        const tiers = computeDynamicTiers(minVal, maxVal, sorted, metricGetter);
+
+        const tierGroups: TierGroup[] = [];
+        for (const tier of tiers) {
+          const tierRepos = sorted.filter((r) => {
+            const v = metricGetter(r);
+            return v >= tier.min && v < tier.max;
+          });
+          if (tierRepos.length > 0) {
+            tierGroups.push({
+              label: tier.label,
+              repos: tierRepos,
+              total: tierRepos.reduce((sum, repo) => sum + metricGetter(repo), 0),
+            });
+          }
+        }
+
+        // If only 1 tier resulted (all repos in same range), bump up granularity
+        if (tierGroups.length <= 1 && sorted.length > MAX_FLAT) {
+          // Force split into ~5 equal-count groups
+          const chunkSize = Math.ceil(sorted.length / 5);
+          tierGroups.length = 0;
+          for (let i = 0; i < sorted.length; i += chunkSize) {
+            const chunk = sorted.slice(i, i + chunkSize);
+            const hi = metricGetter(chunk[0]);
+            const lo = metricGetter(chunk[chunk.length - 1]);
+            tierGroups.push({
+              label: `★ ${fmtK(lo)}–${fmtK(hi)}`,
+              repos: chunk,
+              total: chunk.reduce((sum, repo) => sum + metricGetter(repo), 0),
+            });
+          }
+        }
+
+      // Layout tier groups like overview groups
+      const gItems: TierLayoutItem[] = tierGroups.map((g) => ({ val: g.total, group: g }));
+      squarify(gItems, 0, 0, W, H);
+
+      const newGroupRects: GroupRect[] = [];
+      const newRects: RepoRect[] = [];
+
+      for (const gi of gItems) {
+        if (!gi.rect) continue;
+        const g = gi.group;
+        const color = detailGroup.color;
+        const GAP = 1.5;
+        const HEADER_H = Math.min(22, Math.max(14, gi.rect.h * 0.06));
+
+        newGroupRects.push({
+          ...gi.rect,
+          lang: g.label,
+          color,
+          count: g.repos.length,
+          total: g.total,
+          headerH: HEADER_H,
+          allRepos: g.repos,
+        });
+
+        const ix = gi.rect.x + GAP;
+        const iy = gi.rect.y + HEADER_H + GAP;
+        const iw = gi.rect.w - GAP * 2;
+        const ih = gi.rect.h - HEADER_H - GAP * 2;
+
+        if (iw > 5 && ih > 5) {
+          const TOP_N = Math.min(6, g.repos.length);
+          const SMALL_MAX = 30;
+          const totalShow = Math.min(g.repos.length, TOP_N + SMALL_MAX);
+          const shown: RepoLayoutItem[] = g.repos.slice(0, totalShow).map((r, idx) => ({
+            val: metricGetter(r),
+            repo: r,
+            origIdx: idx,
+          }));
+
+          if (g.repos.length > totalShow) {
+            const shownTotal = shown.reduce((s, it) => s + it.val, 0);
+            shown.push({
+              val: shownTotal * 0.15,
+              repo: null,
+              origIdx: -1,
+            });
+          }
+
+          squarify(shown, ix, iy, iw, ih);
+          for (let si = 0; si < shown.length; si++) {
+            const it = shown[si];
+            if (!it.rect) continue;
+            const isOthers = it.origIdx === -1;
+            newRects.push({
+              ...it.rect,
+              idx: isOthers ? -1 : it.origIdx,
+              groupIdx: newGroupRects.length - 1,
+              isOthers,
+              othersCount: isOthers ? g.repos.length - totalShow : 0,
+            });
+          }
+        }
+      }
+
+      rectsRef.current = newRects;
+      groupRectsRef.current = newGroupRects;
+      } // end else (grouped layout)
+      allReposRef.current = sorted;
+    }
+  }, [mode, groups, detailGroup, metric, search, getMetricValue, fallbackMetric]);
+
+  // ── Render ──
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    const dpr = devicePixelRatio || 1;
+    const W = canvas.width / dpr;
+    const H = canvas.height / dpr;
+    const rects = rectsRef.current;
+    const gRects = groupRectsRef.current;
+    const hovIdx = hoveredIdxRef.current;
+    const hovG = hoveredGroupRef.current;
+    const activeMetric = activeMetricRef.current;
+
+    ctx.save();
+    ctx.scale(dpr, dpr);
+    ctx.fillStyle = "#0c0c0c";
+    ctx.fillRect(0, 0, W, H);
+
+    if (mode === "overview") {
+      // Group backgrounds
+      for (let gi = 0; gi < gRects.length; gi++) {
+        const g = gRects[gi];
+        const isHov = gi === hovG;
+        const GAP = 1.5;
+        ctx.fillStyle = darken(g.color, 0.25);
+        ctx.fillRect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.h - GAP * 2);
+        ctx.strokeStyle = isHov ? g.color : "rgba(255,255,255,0.05)";
+        ctx.lineWidth = isHov ? 2.5 : 1;
+        ctx.strokeRect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.h - GAP * 2);
+      }
+
+      // Repo cells
+      for (const r of rects) {
+        if (r.isOthers || r.idx < 0) {
+          const gi = gRects[r.groupIdx!];
+          const color = gi?.color || "#888";
+          ctx.fillStyle = darken(color, 0.4);
+          ctx.fillRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+          ctx.strokeStyle = "rgba(0,0,0,0.3)";
+          ctx.lineWidth = 0.5;
+          ctx.strokeRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+          if (r.w > 40 && r.h > 14) {
+            ctx.fillStyle = "rgba(255,255,255,0.3)";
+            ctx.font = `400 ${Math.min(11, Math.max(8, r.h * 0.35))}px system-ui`;
+            ctx.textBaseline = "middle";
+            ctx.fillText(`+${(r.othersCount || 0).toLocaleString()} more`, r.x + 4, r.y + r.h / 2);
+          }
+          continue;
+        }
+
+        const gi = gRects[r.groupIdx!];
+        const group = gi;
+        const repo = group?.allRepos[r.idx];
+        if (!repo) continue;
+        const color = group?.color || "#888";
+        const isHov = r.idx === hovIdx && r.groupIdx === hovG;
+
+        ctx.fillStyle = isHov ? lighten(color, 0.35) : color;
+        ctx.fillRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+        ctx.strokeStyle = "rgba(0,0,0,0.35)";
+        ctx.lineWidth = 0.5;
+        ctx.strokeRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+        if (isHov) {
+          ctx.strokeStyle = "#fff";
+          ctx.lineWidth = 2;
+          ctx.strokeRect(r.x + 1, r.y + 1, r.w - 2, r.h - 2);
+        }
+
+        if (r.w > 32 && r.h > 14) {
+          const name = repo.fullName.split("/")[1] || repo.fullName;
+          const fs = Math.min(20, Math.max(7, Math.min(r.w / (name.length * 0.52), r.h * 0.42)));
+          ctx.fillStyle = contrastText(color);
+          ctx.font = `700 ${fs}px system-ui`;
+          ctx.textBaseline = "middle";
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(r.x + 2, r.y + 1, r.w - 4, r.h - 2);
+          ctx.clip();
+          if (r.h > 28 && fs >= 9) {
+            ctx.fillText(name, r.x + 4, r.y + r.h * 0.36);
+            ctx.font = `400 ${Math.max(7, fs * 0.6)}px system-ui`;
+            ctx.globalAlpha = 0.55;
+            ctx.fillText(formatMetricValue(activeMetric, getMetricValue(repo, activeMetric)), r.x + 4, r.y + r.h * 0.64);
+            ctx.globalAlpha = 1;
+          } else {
+            ctx.fillText(name, r.x + 3, r.y + r.h / 2);
+          }
+          ctx.restore();
+        }
+      }
+
+      // Group headers
+      for (let gi = 0; gi < gRects.length; gi++) {
+        const g = gRects[gi];
+        if (g.w < 50 || g.h < 20) continue;
+        const GAP = 1.5;
+        const isHov = gi === hovG;
+        ctx.fillStyle = darken(g.color, 0.5);
+        ctx.fillRect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.headerH);
+        const fs = Math.min(12, Math.max(8, g.headerH * 0.7));
+        ctx.font = `700 ${fs}px system-ui`;
+        ctx.fillStyle = isHov ? lighten(g.color, 0.3) : g.color;
+        ctx.textBaseline = "middle";
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.headerH);
+        ctx.clip();
+        ctx.fillText(
+          `${g.lang}  ${formatMetricValue(activeMetric, g.total)}  ${g.count.toLocaleString()}`,
+          g.x + 6,
+          g.y + GAP + g.headerH / 2
+        );
+        ctx.restore();
+      }
+    } else {
+      // Detail view — same rendering as overview (tier groups + repo cells)
+      // Group backgrounds
+      for (let gi = 0; gi < gRects.length; gi++) {
+        const g = gRects[gi];
+        const isHov = gi === hovG;
+        const GAP = 1.5;
+        // Vary brightness per tier for visual depth
+        const tierDarken = 0.2 + gi * 0.03;
+        ctx.fillStyle = darken(g.color, tierDarken);
+        ctx.fillRect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.h - GAP * 2);
+        ctx.strokeStyle = isHov ? g.color : "rgba(255,255,255,0.05)";
+        ctx.lineWidth = isHov ? 2.5 : 1;
+        ctx.strokeRect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.h - GAP * 2);
+      }
+
+      // Repo cells
+      for (const r of rects) {
+        if (r.isOthers || r.idx < 0) {
+          const gi = gRects[r.groupIdx!];
+          const color = gi?.color || "#888";
+          ctx.fillStyle = darken(color, 0.4);
+          ctx.fillRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+          ctx.strokeStyle = "rgba(0,0,0,0.3)";
+          ctx.lineWidth = 0.5;
+          ctx.strokeRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+          if (r.w > 40 && r.h > 14) {
+            ctx.fillStyle = "rgba(255,255,255,0.3)";
+            ctx.font = `400 ${Math.min(11, Math.max(8, r.h * 0.35))}px system-ui`;
+            ctx.textBaseline = "middle";
+            ctx.fillText(`+${(r.othersCount || 0).toLocaleString()} more`, r.x + 4, r.y + r.h / 2);
+          }
+          continue;
+        }
+
+        const gi = gRects[r.groupIdx!];
+        const repo = gi?.allRepos[r.idx];
+        if (!repo) continue;
+        const color = gi?.color || "#888";
+        const isHov = r.idx === hovIdx && r.groupIdx === hovG;
+
+        ctx.fillStyle = isHov ? lighten(color, 0.35) : color;
+        ctx.fillRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+        ctx.strokeStyle = "rgba(0,0,0,0.35)";
+        ctx.lineWidth = 0.5;
+        ctx.strokeRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+        if (isHov) {
+          ctx.strokeStyle = "#fff";
+          ctx.lineWidth = 2;
+          ctx.strokeRect(r.x + 1, r.y + 1, r.w - 2, r.h - 2);
+        }
+
+        if (r.w > 32 && r.h > 14) {
+          const name = repo.fullName.split("/")[1] || repo.fullName;
+          const fs = Math.min(20, Math.max(7, Math.min(r.w / (name.length * 0.52), r.h * 0.42)));
+          ctx.fillStyle = contrastText(color);
+          ctx.font = `700 ${fs}px system-ui`;
+          ctx.textBaseline = "middle";
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(r.x + 2, r.y + 1, r.w - 4, r.h - 2);
+          ctx.clip();
+          if (r.h > 28 && fs >= 9) {
+            ctx.fillText(name, r.x + 4, r.y + r.h * 0.36);
+            ctx.font = `400 ${Math.max(7, fs * 0.6)}px system-ui`;
+            ctx.globalAlpha = 0.55;
+            ctx.fillText(formatMetricValue(activeMetric, getMetricValue(repo, activeMetric)), r.x + 4, r.y + r.h * 0.64);
+            ctx.globalAlpha = 1;
+          } else {
+            ctx.fillText(name, r.x + 3, r.y + r.h / 2);
+          }
+          ctx.restore();
+        }
+      }
+
+      // Group headers (tier labels)
+      for (let gi = 0; gi < gRects.length; gi++) {
+        const g = gRects[gi];
+        if (g.w < 50 || g.h < 20) continue;
+        const GAP = 1.5;
+        const isHov = gi === hovG;
+        ctx.fillStyle = darken(g.color, 0.5);
+        ctx.fillRect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.headerH);
+        const fs = Math.min(12, Math.max(8, g.headerH * 0.7));
+        ctx.font = `700 ${fs}px system-ui`;
+        ctx.fillStyle = isHov ? lighten(g.color, 0.3) : g.color;
+        ctx.textBaseline = "middle";
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(g.x + GAP, g.y + GAP, g.w - GAP * 2, g.headerH);
+        ctx.clip();
+        ctx.fillText(
+          `${g.lang}  ${formatMetricValue(activeMetric, g.total)}  ${g.count.toLocaleString()} repos`,
+          g.x + 6,
+          g.y + GAP + g.headerH / 2
+        );
+        ctx.restore();
+      }
+    }
+
+    ctx.restore();
+  }, [mode, formatMetricValue, getMetricValue]);
+
+  // ── Resize ──
+  const resize = useCallback(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+    const dpr = devicePixelRatio || 1;
+    canvas.width = wrap.clientWidth * dpr;
+    canvas.height = wrap.clientHeight * dpr;
+    canvas.style.width = wrap.clientWidth + "px";
+    canvas.style.height = wrap.clientHeight + "px";
+    computeLayout();
+    render();
+  }, [computeLayout, render]);
+
+  useEffect(() => {
+    resize();
+    const handler = () => resize();
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, [resize]);
+
+  useEffect(() => {
+    // Recompute the canvas treemap layout when data/metric/search change. This
+    // measures the live canvas (an external system) and derives visibility flags
+    // from the result, so the setState inside computeLayout is intentional here.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    computeLayout();
+    render();
+  }, [computeLayout, render]);
+
+  // ── Hit tests ──
+  const hitRepo = (mx: number, my: number) => {
+    const rects = rectsRef.current;
+    for (let i = rects.length - 1; i >= 0; i--) {
+      const r = rects[i];
+      if (r.isOthers) continue;
+      if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) return i;
+    }
+    return -1;
+  };
+  const hitOthers = (mx: number, my: number) => {
+    const rects = rectsRef.current;
+    for (let i = rects.length - 1; i >= 0; i--) {
+      const r = rects[i];
+      if (!r.isOthers) continue;
+      if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) return i;
+    }
+    return -1;
+  };
+  const hitGroup = (mx: number, my: number) => {
+    const g = groupRectsRef.current;
+    for (let i = g.length - 1; i >= 0; i--) {
+      if (mx >= g[i].x && mx < g[i].x + g[i].w && my >= g[i].y && my < g[i].y + g[i].h) return i;
+    }
+    return -1;
+  };
+  const hitHeader = (mx: number, my: number) => {
+    const g = groupRectsRef.current;
+    for (let i = 0; i < g.length; i++) {
+      if (mx >= g[i].x && mx < g[i].x + g[i].w && my >= g[i].y && my < g[i].y + g[i].headerH + 2) return i;
+    }
+    return -1;
+  };
+
+  // ── Mouse events ──
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const gRects = groupRectsRef.current;
+
+      let needRender = false;
+
+      if (mode === "detail") {
+        // Detail view uses same group-based layout now
+        const repoHit = hitRepo(mx, my);
+        if (repoHit >= 0) {
+          const r = rectsRef.current[repoHit];
+          const gi = gRects[r.groupIdx!];
+          const repo = gi?.allRepos[r.idx];
+          if (hoveredIdxRef.current !== r.idx || hoveredGroupRef.current !== r.groupIdx!) {
+            hoveredIdxRef.current = r.idx;
+            hoveredGroupRef.current = r.groupIdx!;
+            needRender = true;
+          }
+          if (repo) showRepoTooltip(e.clientX, e.clientY, repo, detailGroup!.lang, detailGroup!.color);
+          panelRef.current?.hide();
+          canvas.style.cursor = "pointer";
+        } else {
+          if (hoveredIdxRef.current !== -1) { hoveredIdxRef.current = -1; needRender = true; }
+          hideTooltip();
+          const oHit = hitOthers(mx, my);
+          if (oHit >= 0) {
+            const r = rectsRef.current[oHit];
+            const gi = gRects[r.groupIdx!];
+            if (hoveredGroupRef.current !== r.groupIdx!) { hoveredGroupRef.current = r.groupIdx!; needRender = true; }
+            const TOP_N = 6, SMALL_MAX = 30;
+            const skipCount = Math.min(gi.allRepos.length, TOP_N + SMALL_MAX);
+            const hidden = gi.allRepos.slice(skipCount);
+            panelRef.current?.show(e.clientX, e.clientY, {
+              title: `${gi.lang} — more repos`,
+              subtitle: `${hidden.length.toLocaleString()} repos not shown`,
+              color: gi.color,
+              repos: hidden,
+              startRank: skipCount + 1,
+            });
+            canvas.style.cursor = "pointer";
+          } else {
+            if (hoveredGroupRef.current !== -1) { hoveredGroupRef.current = -1; needRender = true; }
+            panelRef.current?.hide();
+            canvas.style.cursor = "default";
+          }
+        }
+      } else {
+        const hdrHit = hitHeader(mx, my);
+        const repoHit = hdrHit < 0 ? hitRepo(mx, my) : -1;
+
+        if (repoHit >= 0) {
+          const r = rectsRef.current[repoHit];
+          const gi = gRects[r.groupIdx!];
+          const repo = gi?.allRepos[r.idx];
+          if (hoveredIdxRef.current !== r.idx || hoveredGroupRef.current !== r.groupIdx!) {
+            hoveredIdxRef.current = r.idx;
+            hoveredGroupRef.current = r.groupIdx!;
+            needRender = true;
+          }
+          if (repo) showRepoTooltip(e.clientX, e.clientY, repo, gi.lang, gi.color);
+          panelRef.current?.hide();
+          canvas.style.cursor = "pointer";
+        } else if (hdrHit >= 0) {
+          if (hoveredIdxRef.current !== -1) { hoveredIdxRef.current = -1; needRender = true; }
+          if (hoveredGroupRef.current !== hdrHit) { hoveredGroupRef.current = hdrHit; needRender = true; }
+          hideTooltip();
+          panelRef.current?.hide();
+          canvas.style.cursor = "pointer";
+        } else {
+          if (hoveredIdxRef.current !== -1) { hoveredIdxRef.current = -1; needRender = true; }
+          hideTooltip();
+          const oHit = hitOthers(mx, my);
+          if (oHit >= 0) {
+            const r = rectsRef.current[oHit];
+            const gi = gRects[r.groupIdx!];
+            if (hoveredGroupRef.current !== r.groupIdx!) { hoveredGroupRef.current = r.groupIdx!; needRender = true; }
+            const TOP_N = 6, SMALL_MAX = 30;
+            const skipCount = Math.min(gi.allRepos.length, TOP_N + SMALL_MAX);
+            const hidden = gi.allRepos.slice(skipCount);
+            panelRef.current?.show(e.clientX, e.clientY, {
+              title: `${gi.lang} — more repos`,
+              subtitle: `${hidden.length.toLocaleString()} repos not shown`,
+              color: gi.color,
+              repos: hidden,
+              startRank: skipCount + 1,
+            });
+            canvas.style.cursor = "pointer";
+          } else {
+            if (hoveredGroupRef.current !== -1) { hoveredGroupRef.current = -1; needRender = true; }
+            panelRef.current?.hide();
+            canvas.style.cursor = "default";
+          }
+        }
+      }
+
+      if (needRender) render();
+    },
+    [detailGroup, hideTooltip, mode, render, showRepoTooltip]
+  );
+
+  const onMouseLeave = useCallback(() => {
+    hoveredIdxRef.current = -1;
+    hoveredGroupRef.current = -1;
+    hideTooltip();
+    panelRef.current?.hide();
+    if (canvasRef.current) canvasRef.current.style.cursor = "default";
+    render();
+  }, [hideTooltip, render]);
+
+  const onClick = useCallback(
+    (e: React.MouseEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+
+      if (mode === "detail") {
+        // Header click → navigate to sub-tier
+        const hdrHit = hitHeader(mx, my);
+        if (hdrHit >= 0) {
+          const g = groupRectsRef.current[hdrHit];
+          // g.lang is the tier label like "★ 5k–10k", extract slug from allRepos range
+          if (g.allRepos.length > 36) {
+            const maxVal = Math.max(...g.allRepos.map(r => r.stars));
+            const minVal = Math.min(...g.allRepos.map(r => r.stars));
+            const slug = `${minVal}-${maxVal + 1}`;
+            onOpenTier?.(slug);
+          }
+          return;
+        }
+        // Repo click → open GitHub
+        const hit = hitRepo(mx, my);
+        if (hit >= 0) {
+          const r = rectsRef.current[hit];
+          const gi = groupRectsRef.current[r.groupIdx!];
+          const repo = gi?.allRepos[r.idx];
+          if (repo) window.open(`https://github.com/${repo.fullName}`, "_blank");
+          return;
+        }
+        // "More" click → navigate to sub-tier
+        const oHit = hitOthers(mx, my);
+        if (oHit >= 0) {
+          const r = rectsRef.current[oHit];
+          const gi = groupRectsRef.current[r.groupIdx!];
+          if (gi.allRepos.length > 36) {
+            const maxVal = Math.max(...gi.allRepos.map(r => r.stars));
+            const minVal = Math.min(...gi.allRepos.map(r => r.stars));
+            const slug = `${minVal}-${maxVal + 1}`;
+            onOpenTier?.(slug);
+          }
+        }
+      } else {
+        const hdrHit = hitHeader(mx, my);
+        if (hdrHit >= 0) {
+          const g = groupRectsRef.current[hdrHit];
+          onOpenLang?.(g.lang);
+          return;
+        }
+        const repoHit = hitRepo(mx, my);
+        if (repoHit >= 0) {
+          const r = rectsRef.current[repoHit];
+          const gi = groupRectsRef.current[r.groupIdx!];
+          const repo = gi?.allRepos[r.idx];
+          if (repo) window.open(`https://github.com/${repo.fullName}`, "_blank");
+          return;
+        }
+        const gh = hitGroup(mx, my);
+        if (gh >= 0) {
+          const g = groupRectsRef.current[gh];
+          onOpenLang?.(g.lang);
+        }
+      }
+    },
+    [mode, onOpenLang, onOpenTier]
+  );
+
+  const breadcrumb: HeaderBreadcrumbItem[] =
+    breadcrumbOverride ??
+    (mode === "overview"
+      ? [{ label: "All Languages" }]
+      : tierLabel
+        ? [
+            { label: "All Languages", onClick: onBackToOverview },
+            { label: detailGroup!.lang, onClick: onBackToLang, color: detailGroup!.color },
+            { label: tierLabel },
+          ]
+        : [
+            { label: "All Languages", onClick: onBackToOverview },
+            { label: detailGroup!.lang, color: detailGroup!.color },
+          ]);
+
+  const info =
+    infoOverride ??
+    (mode === "overview"
+      ? `${total.toLocaleString()} repos · ${groups?.length || 0} languages`
+      : `${detailGroup!.repos.length.toLocaleString()} ${detailGroup!.lang} repos`);
+
+  const emptyMessage = search
+    ? `No repositories match "${search}"`
+    : metric === "growth"
+      ? "No positive 30d growth data in the current dataset"
+      : "No repositories available for this view";
+
+  return (
+    <>
+      <Header
+        breadcrumb={breadcrumb}
+        metric={metric}
+        onMetricChange={setMetric}
+        search={search}
+        onSearchChange={setSearch}
+        info={info}
+        metrics={metricOptions}
+        activeView={activeView}
+        onViewChange={onViewChange}
+      />
+      <div ref={wrapRef} className="flex-1 relative overflow-hidden">
+        <canvas
+          ref={canvasRef}
+          onMouseMove={onMouseMove}
+          onMouseLeave={onMouseLeave}
+          onClick={onClick}
+          className="block w-full h-full"
+        />
+        {fallbackActive && fallbackNotice && (
+          <div className="absolute left-4 top-4 z-10 max-w-md rounded-2xl border border-[#2b3e45] bg-[rgba(12,12,12,0.88)] px-4 py-3 shadow-2xl backdrop-blur-xl">
+            <div className="text-xs uppercase tracking-[0.22em] text-cyan-300/80">Fallback View</div>
+            <div className="mt-1 text-sm font-semibold text-white">{fallbackNotice.title}</div>
+            <div className="mt-1 text-xs leading-5 text-neutral-400">{fallbackNotice.detail}</div>
+          </div>
+        )}
+        {!hasVisibleData && (
+          <div className="absolute inset-0 flex items-center justify-center px-6 text-center pointer-events-none">
+            <div className="max-w-md rounded-2xl border border-white/10 bg-black/40 px-5 py-4 backdrop-blur-md">
+              <div className="text-base font-semibold text-white">{emptyMessage}</div>
+              <div className="mt-1 text-sm text-neutral-400">
+                {metric === "growth"
+                  ? "Try Stars or Forks, or refresh the dataset with real 30d growth values."
+                  : "Try a different metric or search keyword."}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+      <Panel ref={panelRef} />
+      <Tooltip ref={tooltipRef} />
+    </>
+  );
+}

--- a/webapp/lib/treemap/colors.ts
+++ b/webapp/lib/treemap/colors.ts
@@ -1,0 +1,28 @@
+export function lighten(hex: string, amount: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgb(${Math.min(255, r + (255 - r) * amount) | 0},${Math.min(255, g + (255 - g) * amount) | 0},${Math.min(255, b + (255 - b) * amount) | 0})`;
+}
+
+export function darken(hex: string, amount: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgb(${(r * amount) | 0},${(g * amount) | 0},${(b * amount) | 0})`;
+}
+
+export function contrastText(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return lum > 0.5 ? "rgba(0,0,0,0.85)" : "rgba(255,255,255,0.92)";
+}
+
+export function fmtK(n: number): string {
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+  if (n >= 1e4) return (n / 1e3).toFixed(0) + "k";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + "k";
+  return String(n);
+}

--- a/webapp/lib/treemap/data.ts
+++ b/webapp/lib/treemap/data.ts
@@ -1,0 +1,169 @@
+import type { RepoData, Repo, GroupData, Metric } from "./types";
+import { getRepoValue } from "./metrics";
+import { shouldExcludeRepo } from "./repo-classifier";
+
+// NOTE: ported from xiaoxiunique/1k-github-stars. The upstream module imported
+// `@/data/repos.json` at load time and closed over it. For the webapp embed the
+// dataset is fetched at runtime (client-side), so every helper now takes the
+// already-fetched `RepoData` as an argument and stays pure. `getLangSlug` is the
+// one exception — it's a pure string transform with no data dependency, so the
+// Treemap component can import it directly.
+
+export const DAILY_TRENDING_MIN_REPO_AGE_DAYS = 7;
+export const DAILY_TRENDING_MIN_BASELINE_STARS = 2500;
+
+function filteredRows(data: RepoData): RepoData["repos"] {
+  return data.repos.filter((row) => {
+    const langName = data.langs[row[3]] || "Other";
+    return !shouldExcludeRepo(row[0], row[4] ?? "", langName);
+  });
+}
+
+function curatedRows(data: RepoData): RepoData["repos"] {
+  return data.repos.filter((row) => {
+    const langName = data.langs[row[3]] || "Other";
+    return shouldExcludeRepo(row[0], row[4] ?? "", langName);
+  });
+}
+
+function mapRowsToRepos(rows: RepoData["repos"]): Repo[] {
+  return rows.map((r) => ({
+    fullName: r[0],
+    stars: r[1],
+    forks: r[2],
+    langIdx: r[3],
+    description: r[4],
+    growth: r[5],
+  }));
+}
+
+function normalizeLangSlug(value: string) {
+  return value
+    .toLowerCase()
+    .replaceAll("c++", "c-plus-plus")
+    .replaceAll("c#", "c-sharp")
+    .replaceAll("f#", "f-sharp")
+    .replaceAll("objective-c++", "objective-c-plus-plus")
+    .replaceAll("+", "-plus-")
+    .replaceAll("#", "-sharp")
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function getAllRepos(data: RepoData): Repo[] {
+  return mapRowsToRepos(filteredRows(data));
+}
+
+export function getCuratedRepos(data: RepoData): Repo[] {
+  return mapRowsToRepos(curatedRows(data));
+}
+
+export function getLangs(data: RepoData): string[] {
+  return data.langs;
+}
+
+export function getColors(data: RepoData): string[] {
+  return data.colors;
+}
+
+export function getTotal(data: RepoData): number {
+  return filteredRows(data).length;
+}
+
+export function getCuratedTotal(data: RepoData): number {
+  return curatedRows(data).length;
+}
+
+export function getExportedAt(data: RepoData): string {
+  return data.exported;
+}
+
+function groupRepos(data: RepoData, repos: Repo[], metric: Metric = "stars"): GroupData[] {
+  const langs = getLangs(data);
+  const colors = getColors(data);
+  const groups = new Map<string, { repos: Repo[]; total: number }>();
+
+  for (const repo of repos) {
+    const v = getRepoValue(repo, metric);
+    if (v <= 0) continue;
+    const lang = langs[repo.langIdx] || "Other";
+    if (!groups.has(lang)) groups.set(lang, { repos: [], total: 0 });
+    const g = groups.get(lang)!;
+    g.repos.push(repo);
+    g.total += v;
+  }
+
+  return [...groups.entries()]
+    .map(([lang, g]) => {
+      const langIdx = langs.indexOf(lang);
+      return {
+        lang,
+        color: langIdx >= 0 ? colors[langIdx] : "#888",
+        count: g.repos.length,
+        total: g.total,
+        repos: g.repos.sort(
+          (a, b) => getRepoValue(b, metric) - getRepoValue(a, metric)
+        ),
+      };
+    })
+    .sort((a, b) => b.total - a.total);
+}
+
+export function getGroups(data: RepoData, metric: Metric = "stars"): GroupData[] {
+  return groupRepos(data, getAllRepos(data), metric);
+}
+
+export function getCuratedGroups(data: RepoData, metric: Metric = "stars"): GroupData[] {
+  return groupRepos(data, getCuratedRepos(data), metric);
+}
+
+export function getDailyTrendingData(data: RepoData) {
+  const exportedAtMs = new Date(data.exported).getTime();
+  const eligibleRepos: Repo[] = [];
+  let positiveGrowthRepoCount = 0;
+
+  for (const row of filteredRows(data)) {
+    const growth = row[5] ?? 0;
+    const baselineStars = row[1] - growth;
+    const createdAt = row[6];
+    const createdAtMs = createdAt ? new Date(createdAt).getTime() : Number.NaN;
+
+    if (baselineStars < DAILY_TRENDING_MIN_BASELINE_STARS) continue;
+    if (!Number.isFinite(createdAtMs)) continue;
+    if (exportedAtMs - createdAtMs < DAILY_TRENDING_MIN_REPO_AGE_DAYS * 24 * 60 * 60 * 1000) continue;
+
+    if (growth > 0) {
+      positiveGrowthRepoCount += 1;
+    }
+
+    eligibleRepos.push({
+      fullName: row[0],
+      stars: row[1],
+      forks: row[2],
+      langIdx: row[3],
+      description: row[4],
+      growth,
+    });
+  }
+
+  return {
+    groups: groupRepos(data, eligibleRepos),
+    eligibleRepoCount: eligibleRepos.length,
+    positiveGrowthRepoCount,
+  };
+}
+
+export function getGroupByLang(data: RepoData, lang: string): GroupData | null {
+  const groups = getGroups(data);
+  const normalized = normalizeLangSlug(lang);
+  return groups.find((g) => getLangSlug(g.lang) === normalized) ?? null;
+}
+
+export function getAllLangSlugs(data: RepoData): string[] {
+  const groups = getGroups(data);
+  return groups.map((g) => getLangSlug(g.lang));
+}
+
+export function getLangSlug(lang: string): string {
+  return normalizeLangSlug(lang);
+}

--- a/webapp/lib/treemap/metrics.ts
+++ b/webapp/lib/treemap/metrics.ts
@@ -1,0 +1,8 @@
+import type { Repo, Metric } from "./types";
+
+export function getRepoValue(repo: Repo, metric: Metric): number {
+  if (metric === "stars") return repo.stars;
+  if (metric === "forks") return repo.forks;
+  if (metric === "growth") return Math.max(repo.growth, 0);
+  return repo.stars;
+}

--- a/webapp/lib/treemap/repo-classifier.ts
+++ b/webapp/lib/treemap/repo-classifier.ts
@@ -1,0 +1,105 @@
+const FORCE_INCLUDE = new Set([
+  "microsoft/PowerToys",
+  "FortAwesome/Font-Awesome",
+  "openai/codex",
+  "anthropics/claude-code",
+]);
+
+const STRONG_NAME_KEYWORDS = [
+  "awesome",
+  "roadmap",
+  "guide",
+  "tutorial",
+  "interview",
+  "handbook",
+  "primer",
+  "cookbook",
+  "course",
+  "best-practice",
+  "bestpractices",
+  "project-based-learning",
+  "app-ideas",
+  "howtocook",
+  "days-of",
+  "guidelines",
+  "challenge",
+  "challenges",
+  "examples",
+];
+
+const STRONG_DESCRIPTION_KEYWORDS = [
+  "curated list",
+  "awesome list",
+  "interactive roadmap",
+  "study plan",
+  "interview preparation",
+  "interview questions",
+  "step-by-step guide",
+  "style guide",
+  "programming challenge",
+  "coding challenge",
+  "type challenges",
+  "examples and tutorials",
+  "tutorial and examples",
+  "examples for",
+  "implementations/tutorials",
+  "full text",
+  "learn how to",
+  "prep for",
+  "resources",
+  "guides",
+  "tutorial",
+  "roadmap",
+];
+
+const WEAK_DESCRIPTION_KEYWORDS = [
+  "collection of",
+  "a collection of",
+  "a list of",
+  "examples and guides",
+  "manuals",
+  "cheatsheets",
+  "examples",
+  "samples",
+  "templates",
+];
+
+function scoreKeywordMatches(text: string, keywords: string[], weight: number) {
+  return keywords.reduce(
+    (score, keyword) => score + (text.includes(keyword) ? weight : 0),
+    0
+  );
+}
+
+export function shouldExcludeRepo(
+  fullName: string,
+  description: string,
+  langName: string
+) {
+  if (FORCE_INCLUDE.has(fullName)) {
+    return false;
+  }
+
+  const haystackName = fullName.replace(/[._]/g, "-").toLowerCase();
+  const haystackDescription = (description ?? "").toLowerCase();
+
+  if (STRONG_NAME_KEYWORDS.some((keyword) => haystackName.includes(keyword))) {
+    return true;
+  }
+
+  let score = 0;
+  score += scoreKeywordMatches(haystackDescription, STRONG_DESCRIPTION_KEYWORDS, 2);
+  score += scoreKeywordMatches(haystackDescription, WEAK_DESCRIPTION_KEYWORDS, 1);
+
+  if (
+    (langName === "Markdown" ||
+      langName === "MDX" ||
+      langName === "Other" ||
+      langName === "Jupyter Notebook") &&
+    score >= 2
+  ) {
+    score += 1;
+  }
+
+  return score >= 3;
+}

--- a/webapp/lib/treemap/squarify.ts
+++ b/webapp/lib/treemap/squarify.ts
@@ -1,0 +1,96 @@
+interface SquarifyItem {
+  val: number;
+  area?: number;
+  rect?: { x: number; y: number; w: number; h: number };
+  [key: string]: unknown;
+}
+
+function worstAspect(row: SquarifyItem[], rowArea: number, shortSide: number): number {
+  if (rowArea <= 0 || shortSide <= 0) return Infinity;
+  const rowLen = rowArea / shortSide;
+  let worst = 0;
+  for (const it of row) {
+    const s = it.area! / rowLen;
+    const r = Math.max(rowLen / s, s / rowLen);
+    if (r > worst) worst = r;
+  }
+  return worst;
+}
+
+function placeRow(
+  row: SquarifyItem[],
+  rowArea: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number
+) {
+  if (w >= h) {
+    const rowW = rowArea / h;
+    let ry = y;
+    for (const it of row) {
+      const itemH = it.area! / rowW;
+      it.rect = { x, y: ry, w: rowW, h: itemH };
+      ry += itemH;
+    }
+  } else {
+    const rowH = rowArea / w;
+    let rx = x;
+    for (const it of row) {
+      const itemW = it.area! / rowH;
+      it.rect = { x: rx, y, w: itemW, h: rowH };
+      rx += itemW;
+    }
+  }
+}
+
+export function squarify<T extends SquarifyItem>(
+  items: T[],
+  x: number,
+  y: number,
+  w: number,
+  h: number
+): void {
+  if (!items.length || w <= 0 || h <= 0) return;
+  const totalVal = items.reduce((s, it) => s + it.val, 0);
+  if (totalVal <= 0) return;
+  const totalArea = w * h;
+  for (const it of items) it.area = (it.val / totalVal) * totalArea;
+
+  let pos = 0;
+  while (pos < items.length && w > 0.1 && h > 0.1) {
+    if (pos === items.length - 1) {
+      items[pos].rect = { x, y, w, h };
+      break;
+    }
+    const ss = Math.min(w, h);
+    let row = [items[pos]];
+    let ra = items[pos].area!;
+    let bw = worstAspect(row, ra, ss);
+    let end = pos + 1;
+
+    while (end < items.length) {
+      const newArea = ra + items[end].area!;
+      const newRow = row.concat(items[end]);
+      const ww = worstAspect(newRow, newArea, ss);
+      if (ww <= bw) {
+        row = newRow;
+        ra = newArea;
+        bw = ww;
+        end++;
+      } else break;
+    }
+
+    placeRow(row, ra, x, y, w, h);
+    if (w >= h) {
+      const d = ra / h;
+      x += d;
+      w -= d;
+    } else {
+      const d = ra / w;
+      y += d;
+      h -= d;
+    }
+    pos = end;
+  }
+}

--- a/webapp/lib/treemap/tiers.ts
+++ b/webapp/lib/treemap/tiers.ts
@@ -1,0 +1,94 @@
+import type { Repo, Metric } from "./types";
+import { getRepoValue } from "./metrics";
+
+export interface Tier {
+  label: string;
+  slug: string;
+  min: number;
+  max: number;
+}
+
+// Generate sub-tiers for a given range
+// If range is large, split into meaningful sub-ranges
+export function generateSubTiers(min: number, max: number): Tier[] {
+  const range = max - min;
+
+  // Find good split points
+  const tiers: Tier[] = [];
+
+  if (range <= 0) return [];
+
+  // Dynamic splitting based on range size
+  let boundaries: number[];
+
+  if (max >= 100000) {
+    boundaries = [100000, 50000, 20000, 10000, 5000, 2000, 0].filter(b => b >= min && b < max);
+  } else if (range > 5000) {
+    // Split into ~4-6 chunks
+    const step = Math.ceil(range / 5 / 1000) * 1000; // round to nearest 1k
+    boundaries = [];
+    for (let b = max; b > min; b -= step) {
+      boundaries.push(b);
+    }
+    if (boundaries[boundaries.length - 1] > min) boundaries.push(min);
+  } else if (range > 1000) {
+    const step = Math.ceil(range / 4 / 500) * 500;
+    boundaries = [];
+    for (let b = max; b > min; b -= step) {
+      boundaries.push(b);
+    }
+    if (boundaries[boundaries.length - 1] > min) boundaries.push(min);
+  } else {
+    // Small range, split into ~3 chunks
+    const step = Math.ceil(range / 3 / 100) * 100;
+    boundaries = [];
+    for (let b = max; b > min; b -= step) {
+      boundaries.push(b);
+    }
+    if (boundaries[boundaries.length - 1] > min) boundaries.push(min);
+  }
+
+  boundaries.sort((a, b) => b - a);
+
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    const hi = boundaries[i];
+    const lo = boundaries[i + 1];
+    const label = `★ ${fmtTierNum(lo)}–${fmtTierNum(hi)}`;
+    const slug = `${lo}-${hi}`;
+    tiers.push({ label, slug, min: lo, max: hi });
+  }
+
+  return tiers;
+}
+
+function fmtTierNum(n: number): string {
+  if (n >= 1000) return (n / 1000) + "k";
+  return String(n);
+}
+
+// Top-level tiers (used by detail page)
+export const TOP_TIERS: Tier[] = [
+  { label: "★ 100k+", slug: "100000-Infinity", min: 100000, max: Infinity },
+  { label: "★ 50k–100k", slug: "50000-100000", min: 50000, max: 100000 },
+  { label: "★ 20k–50k", slug: "20000-50000", min: 20000, max: 50000 },
+  { label: "★ 10k–20k", slug: "10000-20000", min: 10000, max: 20000 },
+  { label: "★ 5k–10k", slug: "5000-10000", min: 5000, max: 10000 },
+  { label: "★ 2k–5k", slug: "2000-5000", min: 2000, max: 5000 },
+  { label: "★ 1k–2k", slug: "1000-2000", min: 1000, max: 2000 },
+];
+
+export function parseTierSlug(slug: string): { min: number; max: number } | null {
+  const parts = slug.split("-");
+  if (parts.length !== 2) return null;
+  const min = Number(parts[0]);
+  const max = parts[1] === "Infinity" ? Infinity : Number(parts[1]);
+  if (isNaN(min) || (isNaN(max) && max !== Infinity)) return null;
+  return { min, max };
+}
+
+export function filterReposByTier(repos: Repo[], min: number, max: number, metric: Metric = "stars"): Repo[] {
+  return repos.filter(r => {
+    const v = getRepoValue(r, metric);
+    return v >= min && v < max;
+  }).sort((a, b) => getRepoValue(b, metric) - getRepoValue(a, metric));
+}

--- a/webapp/lib/treemap/types.ts
+++ b/webapp/lib/treemap/types.ts
@@ -1,0 +1,51 @@
+export interface Repo {
+  fullName: string;
+  stars: number;
+  forks: number;
+  langIdx: number;
+  description: string;
+  growth: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface RepoData {
+  langs: string[];
+  colors: string[];
+  repos: [string, number, number, number, string, number, string?, string?][];
+  total: number;
+  exported: string;
+}
+
+export interface GroupData {
+  lang: string;
+  color: string;
+  count: number;
+  total: number;
+  repos: Repo[];
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface RepoRect extends Rect {
+  idx: number;
+  isOthers?: boolean;
+  othersCount?: number;
+  groupIdx?: number;
+}
+
+export interface GroupRect extends Rect {
+  lang: string;
+  color: string;
+  count: number;
+  total: number;
+  headerH: number;
+  allRepos: Repo[];
+}
+
+export type Metric = "stars" | "forks" | "growth";


### PR DESCRIPTION
Ports the third-party `xiaoxiunique/1k-github-stars` treemap into the webapp as a client-rendered route at **`/ghstars`**, with prominent credit to the original author.

Source is namespaced under `lib/treemap/` + `components/treemap/`; `data.ts` was refactored from a build-time `import` into pure functions over a fetched `RepoData`; the upstream's separate routes (`/awesome`, `/daily-trading`, `/[lang]`) collapse into client state (tabs + language/tier drill, no router). The dark theme is scoped via Tailwind on the page wrapper, so the light homepage `globals.css` is untouched. The ~9.4 MB dataset is gitignored under `public/treemap-data/` and fetched at runtime — present in `npm run dev`, with a graceful "dataset unavailable" empty state on Vercel. Hover metadata is fetched from `github-treemap.pages.dev`.

Verified: clean `npm run build` (`/ghstars` prerenders), ESLint 0 errors, dev smoke test (route 200, dataset served, homepage link, empty-state path).

**Known limitation:** live data shows only in local dev; Vercel shows the empty state until data hosting is solved (out of scope). **Licensing:** upstream has no LICENSE; incorporated with visible attribution.

Closes #139
