### PR TITLE
feat: Viridis colors for /ghstars tiers (#141)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-16
+
+### feat: color /ghstars star-range tiers with a Viridis ramp (issue #141)
+
+- `webapp/lib/treemap/colors.ts`: added `viridis(t)` (6-stop perceptually-uniform ramp, dark purple → bright yellow) and `tierColor(rank, count)`, which maps a tier's star rank to the ramp (highest-star tier → bright end).
+- `webapp/components/treemap/Treemap.tsx`: the detail-view star-range tiers now color by rank via `tierColor(...)` instead of reusing the single GitHub-linguist `detailGroup.color`. The tier layout loop is indexed (`squarify` preserves star-descending order). A webapp-side override only — `repos.json` / dataset generation untouched, and language-overview blocks keep their linguist colors.
+- `webapp/TEST-PLAN.md`: added § 20e covering tier coloring.
+
 ## 2026-06-15
 
 ### feat: embed GitHub treemap as /ghstars route in webapp (issue #139)

--- a/webapp/TEST-PLAN.md
+++ b/webapp/TEST-PLAN.md
@@ -1189,6 +1189,18 @@ Issue #139 ports the third-party `xiaoxiunique/1k-github-stars` treemap into the
 | 20d.2 | `grep -rnF 'next/navigation' components/treemap` | No matches — routing replaced by client-state callbacks. |
 | 20d.3 | `grep -nF 'public/treemap-data/' .gitignore` | One match — the dataset dir is gitignored. |
 
+### 20e. Star-range tier colors (issue #141)
+
+Detail-view star-range tiers are colored by a webapp-side Viridis ramp (`tierColor` in `lib/treemap/colors.ts`) keyed to star rank — brightest yellow = highest-star tier, purple = lowest. Overview language blocks keep their linguist colors.
+
+| ID | Steps | Expected |
+|---|---|---|
+| 20e.1 | Drill into a language with several tiers (e.g. JavaScript). | Each `★ a–b` tier is a distinct Viridis color; the highest-star tier is bright yellow (≈`#fde725`), descending toward purple (`#440154`) for the lowest. |
+| 20e.2 | Compare the same view across two languages. | Tier colors depend only on star rank, not language — the highest tier is the same yellow in both. |
+| 20e.3 | Return to overview (any tab). | Language blocks still use their GitHub-linguist colors (e.g. TypeScript blue, Go cyan) — the Viridis scheme applies only to tiers. |
+| 20e.4 | Hover/click tiers; click a tier to sub-drill. | Hover lighten/darken shading and black/white label contrast still work; sub-tiers are themselves Viridis-colored by rank. |
+| 20e.5 | Inspect `lib/treemap/data.ts` color logic + `repos.json`. | Unchanged — the override is webapp-only; dataset colors are untouched. |
+
 ## Exit criteria
 
 A change ships when:

--- a/webapp/components/treemap/Treemap.tsx
+++ b/webapp/components/treemap/Treemap.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { squarify } from "@/lib/treemap/squarify";
-import { lighten, darken, contrastText, fmtK } from "@/lib/treemap/colors";
+import { lighten, darken, contrastText, fmtK, tierColor } from "@/lib/treemap/colors";
 import { getRepoValue } from "@/lib/treemap/metrics";
 import { Header, type HeaderBreadcrumbItem, type TreemapView } from "./Header";
 import { Panel, type PanelHandle } from "./Panel";
@@ -526,10 +526,13 @@ export function Treemap({
       const newGroupRects: GroupRect[] = [];
       const newRects: RepoRect[] = [];
 
-      for (const gi of gItems) {
+      for (let tierRank = 0; tierRank < gItems.length; tierRank++) {
+        const gi = gItems[tierRank];
         if (!gi.rect) continue;
         const g = gi.group;
-        const color = detailGroup.color;
+        // Webapp-side override: color each star-range tier by its rank along a
+        // Viridis ramp (gItems is star-descending, so rank 0 = highest = bright).
+        const color = tierColor(tierRank, gItems.length);
         const GAP = 1.5;
         const HEADER_H = Math.min(22, Math.max(14, gi.rect.h * 0.06));
 

--- a/webapp/lib/treemap/colors.ts
+++ b/webapp/lib/treemap/colors.ts
@@ -20,6 +20,44 @@ export function contrastText(hex: string): string {
   return lum > 0.5 ? "rgba(0,0,0,0.85)" : "rgba(255,255,255,0.92)";
 }
 
+// Viridis sequential ramp (6 anchor stops, dark purple → bright yellow).
+// Perceptually uniform and colorblind-safe. Used to color star-range tiers in
+// the detail view — a webapp-side override of the per-language linguist color.
+const VIRIDIS_STOPS = [
+  "#440154",
+  "#414487",
+  "#2a788e",
+  "#22a884",
+  "#7ad151",
+  "#fde725",
+];
+
+function lerpChannel(a: number, b: number, t: number): number {
+  return Math.round(a + (b - a) * t);
+}
+
+// Sample the Viridis ramp at t ∈ [0,1] (0 = darkest, 1 = brightest). Returns hex.
+export function viridis(t: number): string {
+  const clamped = t <= 0 ? 0 : t >= 1 ? 1 : t;
+  const span = VIRIDIS_STOPS.length - 1;
+  const scaled = clamped * span;
+  const i = Math.min(span - 1, Math.floor(scaled));
+  const local = scaled - i;
+  const from = VIRIDIS_STOPS[i];
+  const to = VIRIDIS_STOPS[i + 1];
+  const r = lerpChannel(parseInt(from.slice(1, 3), 16), parseInt(to.slice(1, 3), 16), local);
+  const g = lerpChannel(parseInt(from.slice(3, 5), 16), parseInt(to.slice(3, 5), 16), local);
+  const b = lerpChannel(parseInt(from.slice(5, 7), 16), parseInt(to.slice(5, 7), 16), local);
+  return `#${[r, g, b].map((c) => c.toString(16).padStart(2, "0")).join("")}`;
+}
+
+// Color for a star-range tier. `rank` is the tier's index in the star-descending
+// tier list (0 = highest-star tier), so the highest tier maps to the bright end.
+export function tierColor(rank: number, count: number): string {
+  const t = count <= 1 ? 1 : (count - 1 - rank) / (count - 1);
+  return viridis(t);
+}
+
 export function fmtK(n: number): string {
   if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
   if (n >= 1e4) return (n / 1e3).toFixed(0) + "k";


### PR DESCRIPTION
Colors the `/ghstars` detail-view star-range tiers with a webapp-side **Viridis** ramp (brightest yellow = highest-star tier, purple = lowest) instead of reusing the single GitHub-linguist language color.

`lib/treemap/colors.ts` gains `viridis(t)` + `tierColor(rank, count)`; `Treemap.tsx`'s tier layout loop is indexed and colors each tier by rank. The override is entirely in the webapp — `repos.json` / dataset generation is untouched, and language-overview blocks keep their linguist colors. Existing hover shading and label contrast still work; sub-tiers are colored by their own rank.

Verified: ramp endpoints exact, clean `npm run build`, ESLint 0 errors, dev route 200.

Closes #141
