### PR TITLE
feat: repo detail bar on /ghstars (#145)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-17
+
+### feat: bottom repo-detail panel on /ghstars (issue #145)
+
+- `webapp/components/treemap/Treemap.tsx`: added a persistent, hover-driven detail bar (`RepoDetailBar`) pinned to the bottom of the `/ghstars` page. It mirrors the hover tooltip's fields — name, owner, description, plus language (color dot + name), ★ stars, ⑂ forks, Growth, Created and Updated dates. The stats sit in fixed-width slots on the first line so they hold the same x-position as you move between repos; the description wraps below (clamped to 2 lines). Sourced from new `detailRepo` state set inside `showRepoTooltip` (so it reuses the language label/color and the lazily-fetched created/updated meta, backfilling once the meta index resolves). Persists the last repo after the cursor leaves the canvas; placeholder before any hover; fixed height keeps the canvas layout stable. Clicking a cell still opens GitHub.
+- `webapp/components/treemap/Tooltip.tsx`: slimmed the floating hover tooltip to just the repo **name + description** now that the bottom bar carries the rest — dropped owner, language, stars, forks, growth, and created/updated from it. `TooltipHandle.show` simplified to `(x, y, repo)`; removed the now-dead `ActiveTooltip`/`activeTooltipRef` and the meta-driven tooltip re-render in `Treemap.tsx` (the bar's date backfill stays).
+- `webapp/TEST-PLAN.md`: added § 21 covering the detail bar.
+
 ## 2026-06-16
 
 ### feat: color /ghstars star-range tiers with a Viridis ramp (issue #141)

--- a/webapp/TEST-PLAN.md
+++ b/webapp/TEST-PLAN.md
@@ -1201,6 +1201,22 @@ Detail-view star-range tiers are colored by a webapp-side Viridis ramp (`tierCol
 | 20e.4 | Hover/click tiers; click a tier to sub-drill. | Hover lighten/darken shading and black/white label contrast still work; sub-tiers are themselves Viridis-colored by rank. |
 | 20e.5 | Inspect `lib/treemap/data.ts` color logic + `repos.json`. | Unchanged — the override is webapp-only; dataset colors are untouched. |
 
+## 21. Bottom repo-detail panel on `/ghstars` (issue #145)
+
+A persistent, hover-driven bar (`RepoDetailBar` in `components/treemap/Treemap.tsx`) is pinned to the bottom of `/ghstars`. Its first line shows **name**, **owner**, **language** (color dot + name), **★ stars**, **⑂ forks**, **Growth**, **Created**, **Updated**, and the **description** wraps below. The transient floating tooltip is now slimmed to just **name + description** (the bar carries everything else); clicking a cell still opens GitHub.
+
+| ID | Steps | Expected |
+|---|---|---|
+| 21.1 | Load `/ghstars` (local dev with `repos.json` present); don't hover anything yet. | A fixed-height bar at the bottom shows the placeholder "Hover a repo to see its details". |
+| 21.2 | Hover a repo cell in the overview. | First line shows the repo's name (bold) + owner (muted) on the left and language, ★ stars, ⑂ forks, Growth (green when positive), Created and Updated dates on the right; description wraps on line 2 (clamped to ~2 lines). Values match the floating tooltip for the same repo. |
+| 21.3 | Hover several repos in turn, comparing the right-hand stats column. | Each stat (language, stars, forks, growth, created, updated) stays at the **same x-position** regardless of name/owner length or value width — fixed-width slots, no horizontal jitter. |
+| 21.4 | Move the cursor off the canvas (away from any cell). | The bar keeps showing the last-hovered repo — it persists, it does not revert to the placeholder. |
+| 21.5 | Drill into a language (click a group header), then hover a repo cell. | The bar updates for repos in the detail/tier view too; the language dot uses the language color (not the Viridis tier color). |
+| 21.6 | Hover a repo, then hover it again after a moment (lets the `repo-meta.json` index load). | Created/Updated show "—" only until the meta index resolves, then fill in with `YYYY-MM-DD` dates (backfilled while still hovering the same repo). |
+| 21.7 | Hover repos with very long descriptions. | Description is clamped (no overflow); the canvas above does not reflow — bar height is fixed. |
+| 21.8 | Click a repo cell. | GitHub opens in a new tab as before — the bar does not change click behavior. |
+| 21.9 | Hover a repo and inspect the floating tooltip near the cursor. | Tooltip shows only the repo **name** (bold) and **description** — no owner, language, stars, forks, growth, or dates (those live only in the bottom bar). |
+
 ## Exit criteria
 
 A change ships when:

--- a/webapp/components/treemap/Tooltip.tsx
+++ b/webapp/components/treemap/Tooltip.tsx
@@ -2,25 +2,10 @@
 
 import { useRef, forwardRef, useImperativeHandle } from "react";
 import type { Repo } from "@/lib/treemap/types";
-import { fmtK } from "@/lib/treemap/colors";
 
 export interface TooltipHandle {
-  show: (
-    x: number,
-    y: number,
-    repo: Repo,
-    langName: string,
-    langColor: string,
-    options?: { metaLoading?: boolean }
-  ) => void;
+  show: (x: number, y: number, repo: Repo) => void;
   hide: () => void;
-}
-
-function formatDate(value?: string, loading = false) {
-  if (!value) return loading ? "Loading..." : "—";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return loading ? "Loading..." : "—";
-  return date.toISOString().slice(0, 10);
 }
 
 function escapeHtml(value: string) {
@@ -36,45 +21,22 @@ export const Tooltip = forwardRef<TooltipHandle>(function Tooltip(_, ref) {
   const elRef = useRef<HTMLDivElement>(null);
 
   useImperativeHandle(ref, () => ({
-    show(x, y, repo, langName, langColor, options) {
+    show(x, y, repo) {
       const el = elRef.current;
       if (!el) return;
-      const [owner, name] = repo.fullName.split("/");
-      const growth =
-        repo.growth > 0
-          ? `<span class="text-green-400">+${fmtK(repo.growth)}</span>`
-          : "—";
-      const createdAt = formatDate(repo.createdAt, options?.metaLoading);
-      const updatedAt = formatDate(repo.updatedAt, options?.metaLoading);
+      const name = repo.fullName.split("/")[1] || repo.fullName;
       const safeName = escapeHtml(name);
-      const safeOwner = escapeHtml(owner);
-      const safeLangName = escapeHtml(langName);
       const safeDescription = repo.description ? escapeHtml(repo.description) : "";
-      const safeCreatedAt = escapeHtml(createdAt);
-      const safeUpdatedAt = escapeHtml(updatedAt);
 
       el.innerHTML = `
-        <div class="font-bold text-[15px] mb-0.5">${safeName}</div>
-        <div class="text-xs text-neutral-500 mb-1.5">${safeOwner}</div>
-        ${safeDescription ? `<div class="text-xs text-neutral-400 leading-relaxed mb-2">${safeDescription}</div>` : ""}
-        <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs">
-          <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full inline-block" style="background:${langColor}"></span>${safeLangName}</span>
-          <span>★ ${fmtK(repo.stars)}</span>
-          <span>⑂ ${fmtK(repo.forks)}</span>
-          <span>Growth: ${growth}</span>
-        </div>
-        <div class="mt-2 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs text-neutral-400">
-          <span class="text-neutral-500">Created</span>
-          <span>${safeCreatedAt}</span>
-          <span class="text-neutral-500">Updated</span>
-          <span>${safeUpdatedAt}</span>
-        </div>`;
+        <div class="font-bold text-[15px]">${safeName}</div>
+        ${safeDescription ? `<div class="mt-0.5 text-xs text-neutral-400 leading-relaxed">${safeDescription}</div>` : ""}`;
 
       el.style.display = "block";
       let tx = x + 16,
         ty = y + 16;
       if (tx + 380 > window.innerWidth) tx = x - 390;
-      const height = el.offsetHeight || 180;
+      const height = el.offsetHeight || 80;
       if (ty + height > window.innerHeight) ty = y - height - 16;
       el.style.left = tx + "px";
       el.style.top = ty + "px";

--- a/webapp/components/treemap/Treemap.tsx
+++ b/webapp/components/treemap/Treemap.tsx
@@ -37,15 +37,6 @@ type RepoLayoutItem = SquarifyRect & {
 
 type RepoMeta = Pick<Repo, "createdAt" | "updatedAt">;
 
-type ActiveTooltip = {
-  fullName: string;
-  x: number;
-  y: number;
-  repo: Repo;
-  langName: string;
-  langColor: string;
-};
-
 type RepoMetaIndex = Record<string, [string | null, string | null]>;
 
 function matchesRepoSearch(repo: Repo, query: string, langName: string) {
@@ -173,6 +164,13 @@ export function Treemap({
   const [search, setSearch] = useState("");
   const [hasVisibleData, setHasVisibleData] = useState(true);
   const [fallbackActive, setFallbackActive] = useState(false);
+  // Most-recently-hovered repo (+ its language label/color), surfaced in the
+  // persistent bottom detail bar. Hover-driven (clicking a cell still opens
+  // GitHub); persists after the cursor leaves the treemap until another repo
+  // is hovered.
+  const [detailRepo, setDetailRepo] =
+    useState<{ repo: Repo; langName: string; langColor: string } | null>(null);
+  const detailRepoNameRef = useRef<string | null>(null);
 
   const rectsRef = useRef<RepoRect[]>([]);
   const groupRectsRef = useRef<GroupRect[]>([]);
@@ -182,7 +180,6 @@ export function Treemap({
   const activeMetricRef = useRef<Metric>(initialMetric);
   const tooltipMetaCacheRef = useRef<Map<string, RepoMeta>>(new Map());
   const tooltipMetaIndexRequestRef = useRef<Promise<void> | null>(null);
-  const activeTooltipRef = useRef<ActiveTooltip | null>(null);
   const searchReadyRef = useRef(false);
 
   const metricOptions = availableMetrics.map((metricKey) => METRIC_OPTIONS[metricKey]);
@@ -194,7 +191,6 @@ export function Treemap({
     return `★ ${fmtK(value)}`;
   }, []);
   const hideTooltip = useCallback(() => {
-    activeTooltipRef.current = null;
     tooltipRef.current?.hide();
   }, []);
   const ensureTooltipMetaIndex = useCallback(() => {
@@ -235,18 +231,14 @@ export function Treemap({
       const cachedMeta = tooltipMetaCacheRef.current.get(repo.fullName);
       const tooltipRepo = cachedMeta ? { ...repo, ...cachedMeta } : repo;
 
-      activeTooltipRef.current = {
-        fullName: repo.fullName,
-        x,
-        y,
-        repo,
-        langName,
-        langColor,
-      };
+      // Mirror into the persistent bottom bar, but only when the hovered repo
+      // changes (this runs on every mousemove over the same cell).
+      if (detailRepoNameRef.current !== repo.fullName) {
+        detailRepoNameRef.current = repo.fullName;
+        setDetailRepo({ repo: tooltipRepo, langName, langColor });
+      }
 
-      tooltipRef.current?.show(x, y, tooltipRepo, langName, langColor, {
-        metaLoading: !cachedMeta,
-      });
+      tooltipRef.current?.show(x, y, tooltipRepo);
 
       if (cachedMeta) {
         return;
@@ -256,16 +248,12 @@ export function Treemap({
         const meta = tooltipMetaCacheRef.current.get(repo.fullName);
         if (!meta) return;
 
-        const activeTooltip = activeTooltipRef.current;
-        if (!activeTooltip || activeTooltip.fullName !== repo.fullName) return;
-
-        tooltipRef.current?.show(
-          activeTooltip.x,
-          activeTooltip.y,
-          { ...activeTooltip.repo, ...meta },
-          activeTooltip.langName,
-          activeTooltip.langColor
-        );
+        // The tooltip only shows name + description (no meta), so nothing to
+        // re-render there — just backfill the bottom bar's Created/Updated once
+        // the meta index resolves, if it's still showing this repo.
+        if (detailRepoNameRef.current === repo.fullName) {
+          setDetailRepo({ repo: { ...repo, ...meta }, langName, langColor });
+        }
       });
     },
     [ensureTooltipMetaIndex]
@@ -1126,8 +1114,90 @@ export function Treemap({
           </div>
         )}
       </div>
+      <RepoDetailBar detail={detailRepo} />
       <Panel ref={panelRef} />
       <Tooltip ref={tooltipRef} />
     </>
+  );
+}
+
+function formatBarDate(value?: string) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toISOString().slice(0, 10);
+}
+
+// Persistent detail bar pinned to the bottom of the treemap. Hover-driven: it
+// mirrors the hover tooltip's fields (name / owner / description plus language,
+// stars, forks, growth, created, updated) and keeps the last repo visible after
+// the cursor leaves the canvas. Fixed height so the canvas layout above stays
+// stable; the stats sit in fixed-width slots so they hold the same position on
+// the first line as you move between repos.
+function RepoDetailBar({
+  detail,
+}: {
+  detail: { repo: Repo; langName: string; langColor: string } | null;
+}) {
+  if (!detail) {
+    return (
+      <div className="h-20 shrink-0 border-t border-white/10 bg-[#0c0c0c] px-4 py-2.5">
+        <div className="flex h-full items-center text-xs text-neutral-500">
+          Hover a repo to see its details
+        </div>
+      </div>
+    );
+  }
+
+  const { repo, langName, langColor } = detail;
+  const [owner, name] = repo.fullName.split("/");
+
+  return (
+    <div className="h-20 shrink-0 border-t border-white/10 bg-[#0c0c0c] px-4 py-2.5">
+      <div className="flex h-full flex-col">
+        <div className="flex items-baseline gap-4">
+          {/* Name + owner: flexible, truncates so the stats stay put. */}
+          <div className="flex min-w-0 flex-1 items-baseline gap-2">
+            <span className="truncate text-sm font-bold text-white">{name || repo.fullName}</span>
+            {owner && name && (
+              <span className="shrink-0 text-xs text-neutral-500">{owner}</span>
+            )}
+          </div>
+          {/* Fixed-width stat slots — same x-position across repos. */}
+          <div className="flex shrink-0 items-baseline gap-4 text-xs text-neutral-400">
+            <span className="flex w-32 items-center gap-1">
+              <span
+                className="inline-block h-2 w-2 shrink-0 rounded-full"
+                style={{ background: langColor }}
+              />
+              <span className="truncate">{langName}</span>
+            </span>
+            <span className="w-16 shrink-0">★ {fmtK(repo.stars)}</span>
+            <span className="w-16 shrink-0">⑂ {fmtK(repo.forks)}</span>
+            <span className="w-24 shrink-0">
+              <span className="text-neutral-500">Growth </span>
+              {repo.growth > 0 ? (
+                <span className="text-green-400">+{fmtK(repo.growth)}</span>
+              ) : (
+                "—"
+              )}
+            </span>
+            <span className="w-36 shrink-0">
+              <span className="text-neutral-500">Created </span>
+              {formatBarDate(repo.createdAt)}
+            </span>
+            <span className="w-36 shrink-0">
+              <span className="text-neutral-500">Updated </span>
+              {formatBarDate(repo.updatedAt)}
+            </span>
+          </div>
+        </div>
+        {repo.description && (
+          <div className="mt-1 line-clamp-2 text-xs leading-relaxed text-neutral-400">
+            {repo.description}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Adds a persistent, hover-driven detail bar pinned to the bottom of `/ghstars`. Its first line shows the hovered repo's name, owner, language, ★ stars, ⑂ forks, Growth, and Created/Updated dates in fixed-width slots (so they hold the same x-position across repos), with the description wrapping below. It persists the last-hovered repo after the cursor leaves the canvas, shows a placeholder before any hover, and uses a fixed height so the canvas layout stays stable. Clicking a cell still opens GitHub.

Now that the bar carries the full field set, the floating hover tooltip is slimmed to just name + description; the dead `ActiveTooltip`/`activeTooltipRef` and the meta-driven tooltip re-render were removed.

Verified end-to-end in a real browser (Playwright/Chromium) against the live dev server; `tsc` + `eslint` clean.

Closes #145
