### PR TITLE
docs: document local-dev setup gotchas (#144)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-17
+
+### docs: document local-dev setup gotchas (issue #144)
+
+- `webapp/README.md`: added a Node.js ≥ 20.9 prerequisite note and a Troubleshooting section for the WSL failure (old system Node + npm-9 optional-deps bug → Next refusing to start / Tailwind "Cannot find native binding"), with the nvm-based fix.
+- `webapp/README.md`: documented the `/ghstars` treemap dataset with a verified `curl` command to fetch `repos.json` into `public/treemap-data/`.
+- `api/server/README.md`: noted that an existing `.venv` must be re-synced (`pip install -r requirements.txt`) when `requirements.txt` changes, since a missing dep surfaces as a runtime `ModuleNotFoundError`, not a startup error.
+
 ## 2026-06-16
 
 ### feat: color /ghstars star-range tiers with a Viridis ramp (issue #141)

--- a/api/server/README.md
+++ b/api/server/README.md
@@ -26,6 +26,18 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+> **Already have a `.venv`?** Re-run the install whenever `requirements.txt`
+> changes (e.g. after `git pull`) so new deps land — an existing venv won't
+> pick them up on its own:
+>
+> ```bash
+> source .venv/bin/activate
+> pip install -r requirements.txt
+> ```
+>
+> A missing dep surfaces as a `ModuleNotFoundError` (e.g. `No module named
+> 'google'`) only when the route that imports it is hit, not at startup.
+
 ## Run
 
 ```bash

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -10,6 +10,10 @@ for manual test cases.
 
 ## Getting started
 
+**Requires Node.js ≥ 20.9** (Next.js 16 refuses to start on anything older).
+Check with `node -v`; if you're below that — common on WSL, whose system Node
+is often v18 — see [Troubleshooting](#troubleshooting) before installing.
+
 ```bash
 cp .env.local.example .env.local   # then fill in GNEWS_API_KEY (https://gnews.io)
 npm install
@@ -20,6 +24,23 @@ The 30-day-summary and tool pages enrich themselves from the local FastAPI
 backend at `localhost:8001` when it's running (see
 [../api/server/README.md](../api/server/README.md)); they degrade gracefully
 when it isn't.
+
+## GitHub treemap dataset (`/ghstars`)
+
+The `/ghstars` treemap fetches `public/treemap-data/repos.json` (~9.4 MB) at
+runtime. That folder is **gitignored** and never committed, so you must supply
+the dataset locally. Download it from the upstream
+[`xiaoxiunique/1k-github-stars`](https://github.com/xiaoxiunique/1k-github-stars)
+repo (run from `webapp/`):
+
+```bash
+mkdir -p public/treemap-data
+curl -L https://raw.githubusercontent.com/xiaoxiunique/1k-github-stars/main/data/repos.json \
+  -o public/treemap-data/repos.json
+```
+
+Without it, `/ghstars` renders a graceful "dataset unavailable" empty state
+(this is also why the route is empty on Vercel).
 
 ## Build / lint
 
@@ -34,3 +55,57 @@ Hosted on Vercel with **Root Directory = `webapp`** and a `GNEWS_API_KEY`
 environment variable. News headlines are fetched server-side from `gnews.io`,
 which is why this target needs a Node runtime (Vercel) rather than static
 hosting.
+
+## Troubleshooting
+
+### WSL: `npm run dev` fails with "Cannot find native binding" or a Node version error
+
+The repo runs fine on macOS but breaks on a fresh WSL setup. Both symptoms below
+have the same root cause: **WSL's default system Node is too old** (usually
+v18, which ships with npm 9). Next.js 16 requires Node ≥ 20.9, and npm 9 hits an
+[optional-dependency bug](https://github.com/npm/cli/issues/4828) that silently
+skips installing Tailwind's native binding (`@tailwindcss/oxide-linux-x64-gnu`).
+
+Symptoms:
+
+```
+You are using Node.js 18.x.x. For Next.js, Node.js version ">=20.9.0" is required.
+```
+```
+./app/globals.css
+Error: Cannot find native binding ...
+Caused by: Cannot find module '@tailwindcss/oxide-linux-x64-gnu'
+```
+
+**Fix — upgrade Node, then reinstall cleanly:**
+
+1. Install a recent Node via [nvm](https://github.com/nvm-sh/nvm) (user-local,
+   no `sudo`):
+
+   ```bash
+   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+   source ~/.bashrc
+   nvm install 22 && nvm alias default 22
+   node -v                              # should print v22.x (≥ 20.9)
+   ```
+
+2. Reinstall dependencies from scratch so the correct native binding lands
+   (the old npm-9 `package-lock.json`/`node_modules` are corrupt for this repo):
+
+   ```bash
+   rm -rf node_modules package-lock.json .next
+   npm install
+   npm run dev
+   ```
+
+   > Restore the committed lockfile afterward (`git checkout -- package-lock.json`)
+   > so you don't commit npm-version churn — `node_modules` is already correct.
+
+Notes:
+
+- Do **not** try to fix this by adding `"node"` to `package.json` dependencies —
+  the npm `node` package is a userland shim, not your runtime, and it corrupts
+  the install.
+- Non-interactive shells (CI scripts, some editor/agent terminals) don't
+  auto-load nvm and may still default to the old Node. Prefix such commands with
+  `export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use 22`.


### PR DESCRIPTION
Capture WSL/Node, treemap dataset, and server venv setup fixes in the relevant READMEs so a fresh checkout doesn't re-debug them.

- webapp/README.md: Node >= 20.9 prerequisite + WSL Troubleshooting section (old system Node + npm-9 optional-deps bug), plus a verified curl command to fetch the /ghstars treemap dataset into public/treemap-data/.
- api/server/README.md: re-sync an existing .venv when requirements.txt changes; missing deps surface as a runtime ModuleNotFoundError.