### PR TITLE
fix: scraper scope on multi-article pages (#152)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-06-21
+
+### fix: full-text scraper misses body on multi-`<article>` pages (issue #152)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: `extractReadableText` no longer blindly scopes to the first `<article>` region. It now compares the richest `<article>` region against the whole stripped document and only scopes to the article when it holds ≥ half the page's readable text — otherwise harvests from the whole doc. Fixes Business Insider (and similar) pages that scatter many small `<article>` promo cards with the real body outside all of them; the detail screen previously fell back to GNews's truncated `content`. No regression on single-`<article>` or no-`<article>` pages.
+
 ## 2026-06-17
 
 ### docs: document local-dev setup gotchas (issue #144)

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -1256,24 +1256,43 @@ struct ContentView: View {
         }
     }
 
-    // Heuristic readability extraction: strip non-content blocks, prefer the <article>
-    // region, then collect block-level text. Good across most news sites, not perfect.
+    // Heuristic readability extraction: strip non-content blocks, then collect block-level text
+    // from the best scope. Good across most news sites, not perfect.
     static func extractReadableText(from html: String) -> String {
         let stripped = removeBlocks(
             html,
             tags: ["script", "style", "head", "noscript", "svg",
                    "header", "footer", "nav", "aside", "form", "figure", "button"])
-        // Prefer the first <article>…</article> region when the page has one.
-        let scope = captures(stripped, pattern: "<article\\b[^>]*>(.*?)</article>", group: 1).first ?? stripped
-        let paragraphs = captures(scope, pattern: "<(p|h1|h2|h3|li)\\b[^>]*>(.*?)</\\1>", group: 2)
-            .map { collapseWhitespace(decodeEntities(stripTags($0))) }
-            .filter { $0.count >= 40 }          // drop nav/ad/byline scraps
-            .filter { !looksLikeMarkup($0) }    // drop escaped-HTML/JSON blobs that survived stripping
+        // Pick the scope to harvest paragraphs from. Pages vary: some wrap the body in one
+        // <article> (related-link lists / sidebars sit outside it, so scoping helps), others
+        // scatter many small <article> promo cards with the real body outside all of them
+        // (e.g. Business Insider). So compare the richest <article> region against the whole
+        // doc — only scope to the article when it holds most of the page's readable text;
+        // otherwise the body isn't inside one and the whole doc is the better source.
+        let docParagraphs = readableParagraphs(in: stripped)
+        let articleParagraphs = captures(stripped, pattern: "<article\\b[^>]*>(.*?)</article>", group: 1)
+            .map { readableParagraphs(in: $0) }
+            .max { paragraphCharCount($0) < paragraphCharCount($1) } ?? []
+        let docCount = paragraphCharCount(docParagraphs)
+        let useArticle = docCount > 0 && paragraphCharCount(articleParagraphs) >= docCount / 2
+        let paragraphs = useArticle ? articleParagraphs : docParagraphs
         if !paragraphs.isEmpty {
             return paragraphs.joined(separator: "\n\n")
         }
-        // Fallback: strip every tag from the scope and return whatever text remains.
-        return collapseWhitespace(decodeEntities(stripTags(scope)))
+        // Fallback: strip every tag and return whatever text remains.
+        return collapseWhitespace(decodeEntities(stripTags(stripped)))
+    }
+
+    // Block-level text in a scope, cleaned and filtered down to body-prose candidates.
+    private static func readableParagraphs(in scope: String) -> [String] {
+        captures(scope, pattern: "<(p|h1|h2|h3|li)\\b[^>]*>(.*?)</\\1>", group: 2)
+            .map { collapseWhitespace(decodeEntities(stripTags($0))) }
+            .filter { $0.count >= 40 }          // drop nav/ad/byline scraps
+            .filter { !looksLikeMarkup($0) }    // drop escaped-HTML/JSON blobs that survived stripping
+    }
+
+    private static func paragraphCharCount(_ paragraphs: [String]) -> Int {
+        paragraphs.reduce(0) { $0 + $1.count }
     }
 
     private static func removeBlocks(_ html: String, tags: [String]) -> String {


### PR DESCRIPTION
Fixes the iOS full-text scraper falling back to GNews's truncated `content` on Business Insider (and similar) pages. `extractReadableText` scoped to the first `<article>` region, which on those pages is a tiny subscription-teaser card — the real body sits outside any `<article>`. It now scores scopes, comparing the richest `<article>` region against the whole stripped doc and only scoping to the article when it holds ≥ half the page's readable text. Verified against 4 real pages (2× Business Insider recovered full body; Independent single-`<article>` and TechCrunch no-`<article>` unchanged) plus a simulator screenshot of the detail screen rendering the full body.

Closes #152
