### PR TITLE
perf: skip WKWebView retry on Safari-only reopen (#160)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-22
 
+### perf: skip WKWebView retry when reopening a Safari-only article (issue #160)
+
+- `ios/FirstContact/FirstContact/ContentView.swift`: `loadFullText` now records (session-scoped `safariOnlyArticleURLs`) any article whose full-text fetch failed and fell back to the "Open full article in Safari" link. Reopening that same article skips the ~9s hidden-`WKWebView` retry — which can't clear an interactive Cloudflare challenge anyway — and lands straight on the Safari link. First-time behavior (URLSession → WKWebView → Safari) is unchanged; the fast URLSession path still runs on reopen, so a recovered site still loads inline.
+
 ### feat: cream/dark color scheme for the news views (issue #158)
 
 - `ios/FirstContact/FirstContact/ContentView.swift`: the news views — article cards, the full-article detail screen, the related-news feed, and news loading/empty/failed states — now render on a warm cream background (`#F0EDE6`) with dark text (`#292826`) for a clean reading-app look, replacing the indigo/purple gradient + white text on those screens. The selectable body switches to dark text with a dark-gray selection tint; the image placeholder and "Open in Safari" affordance adapt to the light theme. The home screen (quote, 30-day summary, issues) keeps the gradient. Added `newsBackground`/`newsText` palette constants.

--- a/ios/FirstContact/FirstContact/ContentView.swift
+++ b/ios/FirstContact/FirstContact/ContentView.swift
@@ -346,6 +346,9 @@ struct ContentView: View {
     @State private var detailArticle: Article?
     @State private var articleTextState: ArticleTextState = .loading
     @State private var textSelectionActive = false   // true while the body's selection handles are in use
+    // Article URLs whose full-text fetch failed (only reachable via "Open in Safari"). Session
+    // memory so reopening one skips the costly WKWebView retry that can't beat its bot wall.
+    @State private var safariOnlyArticleURLs: Set<String> = []
     @State private var keywordArticle: Article?      // article whose term to suggest; nil when opened without an article
     @State private var showKeywordPanel = false      // drives panel presentation (article optional)
     @State private var keywordState: KeywordState = .loading
@@ -1445,11 +1448,20 @@ struct ContentView: View {
         // serve normally to a real WebKit engine. Retry through a hidden WKWebView, which
         // presents a genuine Safari fingerprint and runs any JS challenge, then extract
         // from the rendered DOM.
-        if let html = await WebPageFetcher.html(from: url),
+        //
+        // Skip this for an article we've already seen fail: once it fell back to "Open in
+        // Safari", we know its full text requires Safari, and the WKWebView retry can't beat
+        // the bot wall a second time (it never clears Cloudflare's interactive challenge) —
+        // so re-running its ~9s attempt on reopen is pure waste. Go straight to .failed.
+        if !safariOnlyArticleURLs.contains(urlString),
+           let html = await WebPageFetcher.html(from: url),
            case let text = Self.extractReadableText(from: html), !text.isEmpty {
             articleTextState = .loaded(text)
             return
         }
+        // Full text unavailable — remember it so the next open of this article skips the
+        // WKWebView attempt above and lands straight on the Safari link.
+        safariOnlyArticleURLs.insert(urlString)
         articleTextState = .failed
     }
 


### PR DESCRIPTION
Makes the app remember, per session, which articles can only be read via "Open full article in Safari" (their full-text fetch failed), and skips the ~9s hidden-WKWebView retry when reopening them — it can't clear an interactive Cloudflare challenge anyway. First-time behavior is unchanged (URLSession → WKWebView → Safari link), and the fast URLSession path still runs on reopen so a recovered site still loads inline.

Verified: build succeeds, deployed to device; instrumented open→close→reopen shows the reopen logs `wkwebviewSkipped=true` (vs `false` on first open).

Closes #160
