### PR TITLE
feat: product image in DigiKey search (#162)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-26
+
+### feat: product image in DigiKey search result (issue #162)
+
+- `api/server/digikey_client.py`: `get_pricing` now also calls DigiKey's ProductMedia endpoint (`/products/v4/search/{pn}/media`) best-effort in the same session and returns the product photo URL as `image_url` (the "Product Photos" `SmallPhoto`, 200×200; falls back to full-res `Url`/`Thumbnail`). A media failure returns `null` and never blocks pricing. Refactored the request headers into a shared `_api_headers` helper.
+- `webapp/public/digikey-search.html`: renders `image_url` on a white rounded chip above the price headline; silently omits it when absent or if the image fails to load.
+- `webapp/TEST-PLAN.md`: added § 22.
+
 ## 2026-06-22
 
 ### perf: skip WKWebView retry when reopening a Safari-only article (issue #160)

--- a/api/server/digikey_client.py
+++ b/api/server/digikey_client.py
@@ -1,4 +1,5 @@
-"""DigiKey API client: OAuth2 token cache + ProductPricing call + response normalization."""
+"""DigiKey API client: OAuth2 token cache + ProductPricing call (with a best-effort
+ProductMedia photo lookup) + response normalization."""
 
 from __future__ import annotations
 
@@ -11,6 +12,7 @@ import httpx
 
 TOKEN_URL = "https://api.digikey.com/v1/oauth2/token"
 PRODUCT_PRICING_URL_TEMPLATE = "https://api.digikey.com/products/v4/search/{part_number}/pricing"
+PRODUCT_MEDIA_URL_TEMPLATE = "https://api.digikey.com/products/v4/search/{part_number}/media"
 
 LOCALE_LANGUAGE = "en"
 LOCALE_SITE = "US"
@@ -98,28 +100,65 @@ def _pick_variation(variations: list[dict[str, Any]]) -> dict[str, Any]:
     return max(variations, key=lambda v: len(v.get("StandardPricing") or []))
 
 
+def _api_headers(token: str, client_id: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-DIGIKEY-Client-Id": client_id,
+        "X-DIGIKEY-Locale-Language": LOCALE_LANGUAGE,
+        "X-DIGIKEY-Locale-Site": LOCALE_SITE,
+        "X-DIGIKEY-Locale-Currency": LOCALE_CURRENCY,
+        "Accept": "application/json",
+    }
+
+
+def _pick_product_image(media_body: dict[str, Any]) -> str | None:
+    """Pull the product photo URL from a ProductMedia response.
+
+    MediaLinks holds mixed media (datasheets, videos, photos); only "Product Photos"
+    entries carry image URLs. Prefer the 200x200 SmallPhoto for display, then the
+    full-res Url, then the 64x64 Thumbnail.
+    """
+    for link in media_body.get("MediaLinks") or []:
+        if "photo" in (link.get("MediaType") or "").casefold():
+            for key in ("SmallPhoto", "Url", "Thumbnail"):
+                if link.get(key):
+                    return link[key]
+    return None
+
+
+async def _fetch_product_image(
+    client: httpx.AsyncClient, headers: dict[str, str], part_number: str
+) -> str | None:
+    """Best-effort product photo URL. Returns None on any failure — a missing image
+    must never break the pricing response."""
+    try:
+        resp = await client.get(
+            PRODUCT_MEDIA_URL_TEMPLATE.format(part_number=part_number), headers=headers
+        )
+        if resp.status_code != 200:
+            return None
+        return _pick_product_image(resp.json())
+    except (httpx.HTTPError, ValueError):
+        return None
+
+
 async def get_pricing(manufacturer_part_number: str) -> dict[str, Any]:
     """Fetch volume-tier pricing for a manufacturer part number."""
     async with httpx.AsyncClient(timeout=30) as client:
         token = await _get_access_token(client)
         client_id, _ = _get_credentials()
+        headers = _api_headers(token, client_id)
         url = PRODUCT_PRICING_URL_TEMPLATE.format(part_number=manufacturer_part_number)
-        resp = await client.get(
-            url,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "X-DIGIKEY-Client-Id": client_id,
-                "X-DIGIKEY-Locale-Language": LOCALE_LANGUAGE,
-                "X-DIGIKEY-Locale-Site": LOCALE_SITE,
-                "X-DIGIKEY-Locale-Currency": LOCALE_CURRENCY,
-                "Accept": "application/json",
-            },
-        )
+        resp = await client.get(url, headers=headers)
 
-    if resp.status_code == 404:
-        raise DigiKeyError(f"Part not found: {manufacturer_part_number}")
-    if resp.status_code != 200:
-        raise DigiKeyError(f"ProductPricing failed ({resp.status_code}): {resp.text}")
+        if resp.status_code == 404:
+            raise DigiKeyError(f"Part not found: {manufacturer_part_number}")
+        if resp.status_code != 200:
+            raise DigiKeyError(f"ProductPricing failed ({resp.status_code}): {resp.text}")
+
+        # Product photo is supplementary — fetched best-effort in the same session so a
+        # media error never blocks pricing.
+        image_url = await _fetch_product_image(client, headers, manufacturer_part_number)
 
     body = resp.json()
     pricings = body.get("ProductPricings") or []
@@ -145,4 +184,5 @@ async def get_pricing(manufacturer_part_number: str) -> dict[str, Any]:
         "unit_price": selected["unit_price"],
         "tier_quantity": selected["quantity"],
         "tiers": tiers,
+        "image_url": image_url,
     }

--- a/webapp/TEST-PLAN.md
+++ b/webapp/TEST-PLAN.md
@@ -1217,6 +1217,17 @@ A persistent, hover-driven bar (`RepoDetailBar` in `components/treemap/Treemap.t
 | 21.8 | Click a repo cell. | GitHub opens in a new tab as before — the bar does not change click behavior. |
 | 21.9 | Hover a repo and inspect the floating tooltip near the cursor. | Tooltip shows only the repo **name** (bold) and **description** — no owner, language, stars, forks, growth, or dates (those live only in the bottom bar). |
 
+## 22. DigiKey search product image (issue #162)
+
+The DigiKey search result (`public/digikey-search.html` → local backend `/digikey/pricing`) shows the part's product photo above the price. The backend fetches DigiKey's ProductMedia endpoint best-effort and returns `image_url` (the "Product Photos" `SmallPhoto`); the page renders it on a white chip, and silently omits it when absent. Requires the local backend running (`localhost:8001`).
+
+| ID | Steps | Expected |
+|---|---|---|
+| 22.1 | With the backend running, open `/digikey-search.html` and search `STM32F407VGT6`. | A product photo (the LQFP chip) appears on a white rounded chip above the `Qty → $price` headline; price and part numbers render as before. |
+| 22.2 | Search a part DigiKey has no photo for (or temporarily point the image at a 404). | No image is shown; the price/part-number result still renders normally (no broken-image icon, no error). |
+| 22.3 | Inspect the `/digikey/pricing` JSON response (DevTools Network, or curl). | Response includes an `image_url` field — a `mm.digikey.com` `…_sml(200x200).jpg` URL for parts with a photo, `null` otherwise. |
+| 22.4 | Stop the backend and search. | Unchanged from before: the "backend unreachable" error message shows (the image feature doesn't affect the offline path). |
+
 ## Exit criteria
 
 A change ships when:

--- a/webapp/public/digikey-search.html
+++ b/webapp/public/digikey-search.html
@@ -96,6 +96,17 @@
       margin-top: 1.5rem;
       min-height: 5rem;
     }
+    .product-image {
+      display: block;
+      margin: 0 auto 1rem;
+      width: 140px;
+      height: 140px;
+      object-fit: contain;
+      background: white;
+      border-radius: 0.5rem;
+      padding: 0.5rem;
+      box-sizing: border-box;
+    }
     .headline {
       display: flex;
       align-items: baseline;
@@ -152,6 +163,16 @@
 
     function renderResult(data) {
       result.replaceChildren();
+
+      if (data.image_url) {
+        const img = document.createElement('img');
+        img.className = 'product-image';
+        img.src = data.image_url;
+        img.alt = data.manufacturer_part_number + ' product photo';
+        img.referrerPolicy = 'no-referrer';
+        img.onerror = () => img.remove();   // drop silently if the image can't load
+        result.appendChild(img);
+      }
 
       const headline = document.createElement('div');
       headline.className = 'headline';


### PR DESCRIPTION
Adds the part's product photo to the DigiKey search result. The backend `get_pricing` now also calls DigiKey's ProductMedia endpoint (`/products/v4/search/{pn}/media`) best-effort in the same session and returns the photo as `image_url` (the "Product Photos" `SmallPhoto`, falling back to `Url`/`Thumbnail`); a media failure returns `null` and never blocks pricing. The search page renders it on a white chip above the price, dropping it silently when absent/unloadable.

Verified against the live DigiKey API (STM32F407VGT6, NE555P return valid image URLs) and via a headless-Chrome screenshot of the rendered page. Backend is local-only, so this enriches the tool page during local use.

Closes #162
