### PR TITLE
feat: product image in Mouser search (#164)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-26
 
+### feat: product image in Mouser search result (issue #164)
+
+- `api/server/mouser_client.py`: `get_pricing` returns the matched part's inline `ImagePath` as `image_url` (Mouser includes the photo on the Part, so no extra request — unlike DigiKey's separate media call); `null` when absent.
+- `webapp/public/mouser-search.html`: renders `image_url` on a white rounded chip above the price headline; silently omits it when absent or unloadable. Mirrors the DigiKey tool page (#162).
+- `webapp/TEST-PLAN.md`: added § 23.
+
 ### feat: product image in DigiKey search result (issue #162)
 
 - `api/server/digikey_client.py`: `get_pricing` now also calls DigiKey's ProductMedia endpoint (`/products/v4/search/{pn}/media`) best-effort in the same session and returns the product photo URL as `image_url` (the "Product Photos" `SmallPhoto`, 200×200; falls back to full-res `Url`/`Thumbnail`). A media failure returns `null` and never blocks pricing. Refactored the request headers into a shared `_api_headers` helper.

--- a/api/server/mouser_client.py
+++ b/api/server/mouser_client.py
@@ -128,4 +128,6 @@ async def get_pricing(manufacturer_part_number: str) -> dict[str, Any]:
         "unit_price": selected["unit_price"],
         "tier_quantity": selected["quantity"],
         "tiers": tiers,
+        # Mouser includes the product photo inline on the Part (no separate media call).
+        "image_url": matched.get("ImagePath") or None,
     }

--- a/webapp/TEST-PLAN.md
+++ b/webapp/TEST-PLAN.md
@@ -1228,6 +1228,17 @@ The DigiKey search result (`public/digikey-search.html` → local backend `/digi
 | 22.3 | Inspect the `/digikey/pricing` JSON response (DevTools Network, or curl). | Response includes an `image_url` field — a `mm.digikey.com` `…_sml(200x200).jpg` URL for parts with a photo, `null` otherwise. |
 | 22.4 | Stop the backend and search. | Unchanged from before: the "backend unreachable" error message shows (the image feature doesn't affect the offline path). |
 
+## 23. Mouser search product image (issue #164)
+
+The Mouser search result (`public/mouser-search.html` → local backend `/mouser/pricing`) shows the part's product photo above the price, mirroring the DigiKey page (§ 22). Mouser includes the photo inline on the Part (`ImagePath`), so the backend returns it as `image_url` with no extra request. Requires the local backend running (`localhost:8001`).
+
+| ID | Steps | Expected |
+|---|---|---|
+| 23.1 | With the backend running, open `/mouser-search.html` and search `NE555P`. | A product photo (the PDIP-8 package) appears on a white rounded chip above the `Qty → $price` headline; price and part numbers render as before. |
+| 23.2 | Search a part Mouser has no photo for (or temporarily point the image at a 404). | No image is shown; the price/part-number result still renders normally (no broken-image icon, no error). |
+| 23.3 | Inspect the `/mouser/pricing` JSON response (DevTools Network, or curl). | Response includes an `image_url` field — a `mouser.com` image URL for parts with a photo, `null` otherwise. |
+| 23.4 | Stop the backend and search. | Unchanged: the "backend unreachable" error message shows (the image feature doesn't affect the offline path). |
+
 ## Exit criteria
 
 A change ships when:

--- a/webapp/public/mouser-search.html
+++ b/webapp/public/mouser-search.html
@@ -86,6 +86,17 @@
       margin-top: 1.5rem;
       min-height: 5rem;
     }
+    .product-image {
+      display: block;
+      margin: 0 auto 1rem;
+      width: 140px;
+      height: 140px;
+      object-fit: contain;
+      background: white;
+      border-radius: 0.5rem;
+      padding: 0.5rem;
+      box-sizing: border-box;
+    }
     .headline {
       display: flex;
       align-items: baseline;
@@ -142,6 +153,16 @@
 
     function renderResult(data) {
       result.replaceChildren();
+
+      if (data.image_url) {
+        const img = document.createElement('img');
+        img.className = 'product-image';
+        img.src = data.image_url;
+        img.alt = data.manufacturer_part_number + ' product photo';
+        img.referrerPolicy = 'no-referrer';
+        img.onerror = () => img.remove();   // drop silently if the image can't load
+        result.appendChild(img);
+      }
 
       const headline = document.createElement('div');
       headline.className = 'headline';


### PR DESCRIPTION
Mirrors #162 for the Mouser search tool page: shows the part's product photo above the price. Mouser's PartNumberSearch returns the photo inline on the Part as `ImagePath`, so the backend surfaces it as `image_url` with no extra request; the page renders it on a white chip and drops it silently when absent/unloadable.

Verified against the live Mouser API (NE555P returns a valid image URL) and via a headless-Chrome screenshot. Backend is local-only, so this enriches the tool page during local use.

Closes #164
