### PR TITLE
feat: treemap tile hints on touch (#166)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-27
+
+### feat: treemap tile hints on touch devices (issue #166)
+
+- `webapp/components/treemap/Treemap.tsx`: the `/ghstars` treemap is canvas-rendered and only surfaced hints via `onMouseMove`, so iPad/iOS (no pointer) never showed them usably. Added pointer-event handlers (gated on `pointerType`; the synthesized post-tap mouse events iOS fires are ignored so desktop hover/click is unchanged): a first tap reveals a tile's hint — bottom detail bar + an interactive floating hint near the tap — and highlights the tile. Opening the repo happens via a second tap on the same tile or a tap on the floating hint; the floating hint can be dragged to uncover the tiles it covers. Taps on headers/groups/"more" navigate as before; a tap on empty space dismisses. Taps are distinguished from drags by movement, and the canvas gets `touch-action: manipulation`.
+- `webapp/components/treemap/Tooltip.tsx`: the floating hint takes an optional `interactive` mode (pointer-events enabled, "Tap to open · drag to move" affordance) with its own tap/drag pointer handlers and an `onActivate` callback; hover mode stays click-through.
+- `webapp/TEST-PLAN.md`: added § 24.
+
 ## 2026-06-26
 
 ### feat: product image in Mouser search result (issue #164)

--- a/webapp/TEST-PLAN.md
+++ b/webapp/TEST-PLAN.md
@@ -1239,6 +1239,23 @@ The Mouser search result (`public/mouser-search.html` → local backend `/mouser
 | 23.3 | Inspect the `/mouser/pricing` JSON response (DevTools Network, or curl). | Response includes an `image_url` field — a `mouser.com` image URL for parts with a photo, `null` otherwise. |
 | 23.4 | Stop the backend and search. | Unchanged: the "backend unreachable" error message shows (the image feature doesn't affect the offline path). |
 
+## 24. Treemap tile hints on touch devices (issue #166)
+
+On `/ghstars` the treemap is canvas-rendered and only surfaced hints via mouse hover, so iPad/iOS (no pointer) never showed them usably. Pointer-event handlers in `components/treemap/Treemap.tsx` drive touch: the first tap on a repo tile reveals its hint — both the bottom detail bar (§ 21) and an **interactive floating hint** near the tap (label "Tap to open · drag to move") — and highlights the tile. Opening the repo on GitHub happens via **either** a second tap on the same tile **or** a tap on the floating hint. The floating hint can be **dragged** to uncover the tiles it covers. Header/group/"more" cells navigate on a single tap; a tap on empty space dismisses. The synthesized mouse events iOS fires on tap are ignored (gated on `pointerType`), so desktop mouse behaviour is unchanged. Best tested on a real iPad/iPhone, or Chrome DevTools device-toolbar touch emulation (Appendix § G).
+
+| ID | Steps | Expected |
+|---|---|---|
+| 24.1 | On an iPad/iPhone (or DevTools touch emulation), load `/ghstars` and tap a repo tile once. | The bottom detail bar fills in with that repo's name/owner/language/stars/etc. (as § 21 hover does), the tile is highlighted, and a floating hint (name + description + "Tap to open · drag to move") appears near the tap. The browser does **not** navigate to GitHub. |
+| 24.2 | Tap the **same** tile a second time. | GitHub opens in a new tab for that repo. |
+| 24.3 | Tap the **floating hint** itself (a tap, not a drag). | GitHub opens in a new tab for the revealed repo. |
+| 24.4 | Press and **drag** the floating hint, then lift. | The hint follows the finger and stays where released; it does **not** open GitHub (a drag is not a tap). Tiles previously under it are now visible. |
+| 24.5 | Tap one tile, then tap a **different** tile. | The detail bar + highlight + floating hint move to the second tile; GitHub does **not** open (the second tile was a first tap, not a re-tap of the first). |
+| 24.6 | Tap a tile to reveal it, then tap empty space (a gap/margin with no cell). | The selection clears — highlight removed, detail bar resets, floating hint hidden; nothing opens. |
+| 24.7 | Tap a group header (overview) or the "+N more" cell. | Single tap drills in (open language / tier), same as a desktop click — no two-stage needed for navigation cells. |
+| 24.8 | Swipe/drag across the **canvas** (start on a tile, lift elsewhere). | Treated as a drag, not a tap — no reveal and no navigation. |
+| 24.9 | On a **desktop browser with a mouse**, hover and click repo tiles as before. | Unchanged: hover shows the click-through floating tooltip + detail bar; a single click opens GitHub immediately (no reveal-first behavior, no double-open). The hover tooltip shows no "Tap to open" line and cannot be dragged. |
+| 24.10 | On a touchscreen laptop, use the trackpad to click a tile, then separately tap the same tile via touch. | Trackpad click opens immediately (mouse path); touch tap reveals first with the interactive hint (touch path) — each input type behaves per its kind. |
+
 ## Exit criteria
 
 A change ships when:

--- a/webapp/components/treemap/Tooltip.tsx
+++ b/webapp/components/treemap/Tooltip.tsx
@@ -4,8 +4,13 @@ import { useRef, forwardRef, useImperativeHandle } from "react";
 import type { Repo } from "@/lib/treemap/types";
 
 export interface TooltipHandle {
-  show: (x: number, y: number, repo: Repo) => void;
+  show: (x: number, y: number, repo: Repo, interactive?: boolean) => void;
   hide: () => void;
+}
+
+interface TooltipProps {
+  // Called when an interactive (touch) hint is tapped rather than dragged.
+  onActivate?: (fullName: string) => void;
 }
 
 function escapeHtml(value: string) {
@@ -17,20 +22,32 @@ function escapeHtml(value: string) {
     .replaceAll("'", "&#39;");
 }
 
-export const Tooltip = forwardRef<TooltipHandle>(function Tooltip(_, ref) {
+export const Tooltip = forwardRef<TooltipHandle, TooltipProps>(function Tooltip({ onActivate }, ref) {
   const elRef = useRef<HTMLDivElement>(null);
+  const repoRef = useRef<Repo | null>(null);
+  // Active drag of the (touch) hint: corner offset from the finger, the start
+  // point (to tell a tap from a drag), and the captured pointer id.
+  const dragRef = useRef<{ offX: number; offY: number; startX: number; startY: number; moved: boolean; id: number } | null>(null);
 
   useImperativeHandle(ref, () => ({
-    show(x, y, repo) {
+    show(x, y, repo, interactive = false) {
       const el = elRef.current;
       if (!el) return;
+      repoRef.current = repo;
       const name = repo.fullName.split("/")[1] || repo.fullName;
       const safeName = escapeHtml(name);
       const safeDescription = repo.description ? escapeHtml(repo.description) : "";
 
       el.innerHTML = `
         <div class="font-bold text-[15px]">${safeName}</div>
-        ${safeDescription ? `<div class="mt-0.5 text-xs text-neutral-400 leading-relaxed">${safeDescription}</div>` : ""}`;
+        ${safeDescription ? `<div class="mt-0.5 text-xs text-neutral-400 leading-relaxed">${safeDescription}</div>` : ""}
+        ${interactive ? `<div class="mt-1.5 text-[11px] text-neutral-500">Tap to open · drag to move</div>` : ""}`;
+
+      // Interactive (touch) hints receive pointer events so they can be tapped
+      // or dragged; hover (mouse) hints stay click-through.
+      el.style.pointerEvents = interactive ? "auto" : "none";
+      el.style.touchAction = interactive ? "none" : "";
+      el.style.cursor = interactive ? "grab" : "";
 
       el.style.display = "block";
       let tx = x + 16,
@@ -43,13 +60,52 @@ export const Tooltip = forwardRef<TooltipHandle>(function Tooltip(_, ref) {
     },
     hide() {
       if (elRef.current) elRef.current.style.display = "none";
+      repoRef.current = null;
     },
   }));
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    const el = elRef.current;
+    if (!el || el.style.pointerEvents !== "auto") return; // only when interactive
+    e.stopPropagation();
+    const rect = el.getBoundingClientRect();
+    dragRef.current = {
+      offX: e.clientX - rect.left,
+      offY: e.clientY - rect.top,
+      startX: e.clientX,
+      startY: e.clientY,
+      moved: false,
+      id: e.pointerId,
+    };
+    el.setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const d = dragRef.current;
+    const el = elRef.current;
+    if (!d || !el) return;
+    if (Math.hypot(e.clientX - d.startX, e.clientY - d.startY) > 6) d.moved = true;
+    el.style.left = e.clientX - d.offX + "px";
+    el.style.top = e.clientY - d.offY + "px";
+  };
+
+  const onPointerUp = () => {
+    const d = dragRef.current;
+    const el = elRef.current;
+    if (!d || !el) return;
+    el.releasePointerCapture(d.id);
+    dragRef.current = null;
+    // A press that didn't move is a tap → open the repo.
+    if (!d.moved && repoRef.current) onActivate?.(repoRef.current.fullName);
+  };
 
   return (
     <div
       ref={elRef}
-      className="fixed z-50 hidden pointer-events-none max-w-[380px] bg-[rgba(10,10,10,0.92)] border border-white/10 rounded-xl px-4 py-3 backdrop-blur-2xl shadow-2xl"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      className="fixed z-50 hidden max-w-[380px] bg-[rgba(10,10,10,0.92)] border border-white/10 rounded-xl px-4 py-3 backdrop-blur-2xl shadow-2xl"
     />
   );
 });

--- a/webapp/components/treemap/Treemap.tsx
+++ b/webapp/components/treemap/Treemap.tsx
@@ -176,6 +176,13 @@ export function Treemap({
   const groupRectsRef = useRef<GroupRect[]>([]);
   const hoveredIdxRef = useRef(-1);
   const hoveredGroupRef = useRef(-1);
+  // Touch: swallow the click iOS synthesizes after a tap (we handle taps in the
+  // pointer handlers), plus the pointerdown position for tap-vs-drag detection.
+  const suppressClickRef = useRef(false);
+  const pointerDownPosRef = useRef<{ x: number; y: number } | null>(null);
+  // Last pointer kind seen, so the synthesized mouse events iOS fires after a
+  // tap don't drive the hover-only code paths.
+  const lastPointerTypeRef = useRef<string>("mouse");
   const allReposRef = useRef<Repo[]>([]); // for detail panel
   const activeMetricRef = useRef<Metric>(initialMetric);
   const tooltipMetaCacheRef = useRef<Map<string, RepoMeta>>(new Map());
@@ -227,7 +234,7 @@ export function Treemap({
     return request;
   }, []);
   const showRepoTooltip = useCallback(
-    (x: number, y: number, repo: Repo, langName: string, langColor: string) => {
+    (x: number, y: number, repo: Repo, langName: string, langColor: string, floating = true, interactive = false) => {
       const cachedMeta = tooltipMetaCacheRef.current.get(repo.fullName);
       const tooltipRepo = cachedMeta ? { ...repo, ...cachedMeta } : repo;
 
@@ -238,7 +245,9 @@ export function Treemap({
         setDetailRepo({ repo: tooltipRepo, langName, langColor });
       }
 
-      tooltipRef.current?.show(x, y, tooltipRepo);
+      // On touch the floating hint is interactive (tap to open, drag to move it
+      // off the tiles it covers); on hover it's a plain click-through tooltip.
+      if (floating) tooltipRef.current?.show(x, y, tooltipRepo, interactive);
 
       if (cachedMeta) {
         return;
@@ -866,6 +875,9 @@ export function Treemap({
   // ── Mouse events ──
   const onMouseMove = useCallback(
     (e: React.MouseEvent) => {
+      // Ignore the one-shot mousemove iOS synthesizes on tap — touch is driven
+      // by the pointer handlers, which show an interactive hint instead.
+      if (lastPointerTypeRef.current === "touch") return;
       const canvas = canvasRef.current;
       if (!canvas) return;
       const rect = canvas.getBoundingClientRect();
@@ -970,6 +982,8 @@ export function Treemap({
   );
 
   const onMouseLeave = useCallback(() => {
+    // Don't let a synthesized mouseleave tear down a touch reveal.
+    if (lastPointerTypeRef.current === "touch") return;
     hoveredIdxRef.current = -1;
     hoveredGroupRef.current = -1;
     hideTooltip();
@@ -978,14 +992,10 @@ export function Treemap({
     render();
   }, [hideTooltip, render]);
 
-  const onClick = useCallback(
-    (e: React.MouseEvent) => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const rect = canvas.getBoundingClientRect();
-      const mx = e.clientX - rect.left;
-      const my = e.clientY - rect.top;
-
+  // Open the hit repo on GitHub, or drill into a tapped header/group/"more"
+  // cell. Shared by mouse clicks and the second tap of a touch interaction.
+  const openOrNavigate = useCallback(
+    (mx: number, my: number) => {
       if (mode === "detail") {
         // Header click → navigate to sub-tier
         const hdrHit = hitHeader(mx, my);
@@ -1046,6 +1056,95 @@ export function Treemap({
     [mode, onOpenLang, onOpenTier]
   );
 
+  const onClick = useCallback(
+    (e: React.MouseEvent) => {
+      // iOS fires a synthetic click after a tap; the pointer handlers already
+      // dealt with it, so swallow this one.
+      if (suppressClickRef.current) {
+        suppressClickRef.current = false;
+        return;
+      }
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      openOrNavigate(e.clientX - rect.left, e.clientY - rect.top);
+    },
+    [openOrNavigate]
+  );
+
+  // ── Touch events ──
+  // No hover on touch, so a tap reveals the tile's hint in the bottom detail
+  // bar (two-stage: tap to reveal, tap the same tile again to open on GitHub).
+  // Gated on pointerType so mouse behaviour above is untouched.
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    lastPointerTypeRef.current = e.pointerType;
+    if (e.pointerType === "mouse") return;
+    suppressClickRef.current = false;
+    pointerDownPosRef.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      lastPointerTypeRef.current = e.pointerType;
+      if (e.pointerType === "mouse") return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      // Treat a moved finger as a scroll/drag, not a tap.
+      const down = pointerDownPosRef.current;
+      pointerDownPosRef.current = null;
+      if (down && Math.hypot(e.clientX - down.x, e.clientY - down.y) > 10) return;
+
+      // We handle the tap here; suppress the click iOS synthesizes next.
+      suppressClickRef.current = true;
+
+      const rect = canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const gRects = groupRectsRef.current;
+
+      const hdrHit = hitHeader(mx, my);
+      const repoHit = hdrHit < 0 ? hitRepo(mx, my) : -1;
+
+      if (repoHit >= 0) {
+        const r = rectsRef.current[repoHit];
+        const gi = gRects[r.groupIdx!];
+        const repo = gi?.allRepos[r.idx];
+        if (!repo) return;
+        if (detailRepoNameRef.current === repo.fullName) {
+          // Second tap on the already-revealed tile → open it.
+          window.open(`https://github.com/${repo.fullName}`, "_blank");
+          return;
+        }
+        // First tap → reveal hint (interactive floating hint + detail bar) and
+        // highlight the tile.
+        hoveredIdxRef.current = r.idx;
+        hoveredGroupRef.current = r.groupIdx!;
+        panelRef.current?.hide();
+        showRepoTooltip(e.clientX, e.clientY, repo, gi.lang, gi.color, true, true);
+        render();
+        return;
+      }
+
+      // Tapping a header / group / "more" cell navigates, same as a click.
+      if (hdrHit >= 0 || hitOthers(mx, my) >= 0 || hitGroup(mx, my) >= 0) {
+        openOrNavigate(mx, my);
+        return;
+      }
+
+      // Tap on empty space → dismiss the current selection.
+      if (detailRepoNameRef.current !== null) {
+        detailRepoNameRef.current = null;
+        hoveredIdxRef.current = -1;
+        hoveredGroupRef.current = -1;
+        setDetailRepo(null);
+        hideTooltip();
+        render();
+      }
+    },
+    [hideTooltip, openOrNavigate, render, showRepoTooltip]
+  );
+
   const breadcrumb: HeaderBreadcrumbItem[] =
     breadcrumbOverride ??
     (mode === "overview"
@@ -1092,7 +1191,10 @@ export function Treemap({
           onMouseMove={onMouseMove}
           onMouseLeave={onMouseLeave}
           onClick={onClick}
+          onPointerDown={onPointerDown}
+          onPointerUp={onPointerUp}
           className="block w-full h-full"
+          style={{ touchAction: "manipulation" }}
         />
         {fallbackActive && fallbackNotice && (
           <div className="absolute left-4 top-4 z-10 max-w-md rounded-2xl border border-[#2b3e45] bg-[rgba(12,12,12,0.88)] px-4 py-3 shadow-2xl backdrop-blur-xl">
@@ -1116,7 +1218,10 @@ export function Treemap({
       </div>
       <RepoDetailBar detail={detailRepo} />
       <Panel ref={panelRef} />
-      <Tooltip ref={tooltipRef} />
+      <Tooltip
+        ref={tooltipRef}
+        onActivate={(fullName) => window.open(`https://github.com/${fullName}`, "_blank")}
+      />
     </>
   );
 }


### PR DESCRIPTION
Closes #166.

## Summary

The `/ghstars` treemap is canvas-rendered and only surfaced tile hints via `onMouseMove`, so iPad/iOS (no pointer) never showed them usably. This adds a touch path, gated on `pointerType` so desktop mouse behaviour is unchanged.

- **First tap** on a repo tile → reveals its hint (bottom detail bar + an **interactive floating hint** near the tap, "Tap to open · drag to move") and highlights the tile.
- **Open the repo** → second tap on the same tile, or a tap on the floating hint.
- **Drag the floating hint** → it follows the finger and stays put, uncovering tiles beneath; a drag is never treated as a tap.
- Header / group / "+N more" cells navigate on a single tap; a tap on empty space dismisses.
- The synthesized mouse events iOS fires after a tap are ignored (`lastPointerTypeRef`), so they can't double-fire or tear down a reveal. `touch-action: manipulation` removes the tap delay.

## Files

- `webapp/components/treemap/Treemap.tsx` — pointer handlers, synthesized-event guards, two-stage tap.
- `webapp/components/treemap/Tooltip.tsx` — optional `interactive` (tap/drag) mode + `onActivate`.
- `webapp/TEST-PLAN.md` — § 24 (10 cases).
- `ChangeLog.md` — 2026-06-27 entry.

## Verification

`tsc` and `eslint` clean; `/ghstars` compiles and serves with no runtime errors; deployed to Vercel prod for on-device testing. Full tap/drag behaviour verified manually on iPad (see § 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
